### PR TITLE
 refactor: Redis refresh token 저장 방식을 hash 기반으로 변경

### DIFF
--- a/src/main/java/com/example/seedbe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/seedbe/domain/auth/service/AuthService.java
@@ -33,8 +33,13 @@ public class AuthService {
 
         String userId = jwtProvider.getUserIdFromToken(refreshToken);
 
-        String savedRefreshToken = refreshTokenService.getRefreshToken(userId);
-        if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
+        String savedRefreshTokenHash = refreshTokenService.getRefreshTokenHash(userId);
+        if (savedRefreshTokenHash == null) {
+            throw new BusinessException(ErrorType.INVALID_TOKEN);
+        }
+
+        if (!refreshTokenService.matchesRefreshTokenHash(savedRefreshTokenHash, refreshToken)) {
+            refreshTokenService.deleteRefreshToken(userId);
             throw new BusinessException(ErrorType.INVALID_TOKEN);
         }
 

--- a/src/main/java/com/example/seedbe/global/security/jwt/RefreshTokenService.java
+++ b/src/main/java/com/example/seedbe/global/security/jwt/RefreshTokenService.java
@@ -4,7 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeUnit;
+import java.util.HexFormat;
 
 @Service
 @RequiredArgsConstructor
@@ -19,17 +23,31 @@ public class RefreshTokenService {
 
         refreshTokenRedisTemplate.opsForValue().set(
                 REDIS_KEY_PREFIX + userId,
-                refreshToken,
+                hashToken(refreshToken),
                 expirationMs,
                 TimeUnit.MILLISECONDS
         );
     }
 
-    public String getRefreshToken(String userId) {
+    public String getRefreshTokenHash(String userId) {
         return refreshTokenRedisTemplate.opsForValue().get(REDIS_KEY_PREFIX + userId);
+    }
+
+    public boolean matchesRefreshTokenHash(String savedRefreshTokenHash, String refreshToken) {
+        return savedRefreshTokenHash != null && savedRefreshTokenHash.equals(hashToken(refreshToken));
     }
 
     public void deleteRefreshToken(String userId) {
         refreshTokenRedisTemplate.delete(REDIS_KEY_PREFIX + userId);
+    }
+
+    private String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashedBytes = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashedBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is not available.", e);
+        }
     }
 }

--- a/src/test/java/com/example/seedbe/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/seedbe/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,99 @@
+package com.example.seedbe.domain.auth.service;
+
+import com.example.seedbe.domain.user.entity.User;
+import com.example.seedbe.domain.user.enums.Role;
+import com.example.seedbe.domain.user.repository.UserRepository;
+import com.example.seedbe.global.exception.BusinessException;
+import com.example.seedbe.global.security.jwt.JwtProperties;
+import com.example.seedbe.global.security.jwt.JwtProvider;
+import com.example.seedbe.global.security.jwt.RefreshTokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("정상 refresh token이면 새 access/refresh token을 발급하고 refresh token hash를 저장한다.")
+    void reissueTokenSucceedsWithValidRefreshToken() {
+        JwtProperties jwtProperties = new JwtProperties("secret", 3_600_000L, 1_209_600_000L);
+        AuthService authService = new AuthService(jwtProvider, refreshTokenService, userRepository, jwtProperties);
+
+        UUID userId = UUID.randomUUID();
+        String userIdString = userId.toString();
+        String refreshToken = "valid-refresh-token";
+        String savedRefreshTokenHash = "saved-refresh-token-hash";
+        String newAccessToken = "new-access-token";
+        String newRefreshToken = "new-refresh-token";
+        User user = User.builder()
+                .provider("google")
+                .providerId("provider-id")
+                .email("seed@example.com")
+                .nickname("seed")
+                .role(Role.ROLE_USER)
+                .profileUrl("https://example.com/profile.png")
+                .build();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtProvider.getUserIdFromToken(refreshToken)).thenReturn(userIdString);
+        when(refreshTokenService.getRefreshTokenHash(userIdString)).thenReturn(savedRefreshTokenHash);
+        when(refreshTokenService.matchesRefreshTokenHash(savedRefreshTokenHash, refreshToken)).thenReturn(true);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(jwtProvider.createAccessToken(userIdString, Role.ROLE_USER.name())).thenReturn(newAccessToken);
+        when(jwtProvider.createRefreshToken(userIdString)).thenReturn(newRefreshToken);
+
+        authService.reissueToken(refreshToken, response, true);
+
+        verify(refreshTokenService).saveRefreshToken(userIdString, newRefreshToken);
+        verify(refreshTokenService, never()).deleteRefreshToken(userIdString);
+        assertThat(response.getCookie("accessToken").getValue()).isEqualTo(newAccessToken);
+        assertThat(response.getCookie("refreshToken").getValue()).isEqualTo(newRefreshToken);
+        assertThat(response.getCookie("refreshToken").getPath()).isEqualTo("/api/auth");
+    }
+
+    @Test
+    @DisplayName("저장 hash와 요청 refresh token hash가 불일치하면 reuse 의심으로 Redis refresh token을 삭제한다.")
+    void reissueTokenDeletesRefreshTokenWhenHashDoesNotMatch() {
+        JwtProperties jwtProperties = new JwtProperties("secret", 3_600_000L, 1_209_600_000L);
+        AuthService authService = new AuthService(jwtProvider, refreshTokenService, userRepository, jwtProperties);
+
+        UUID userId = UUID.randomUUID();
+        String userIdString = userId.toString();
+        String rotatedRefreshToken = "rotated-refresh-token";
+        String savedRefreshTokenHash = "saved-refresh-token-hash";
+
+        when(jwtProvider.validateToken(rotatedRefreshToken)).thenReturn(true);
+        when(jwtProvider.getUserIdFromToken(rotatedRefreshToken)).thenReturn(userIdString);
+        when(refreshTokenService.getRefreshTokenHash(userIdString)).thenReturn(savedRefreshTokenHash);
+        when(refreshTokenService.matchesRefreshTokenHash(savedRefreshTokenHash, rotatedRefreshToken)).thenReturn(false);
+
+        assertThatThrownBy(() -> authService.reissueToken(rotatedRefreshToken, new MockHttpServletResponse(), true))
+                .isInstanceOf(BusinessException.class);
+
+        verify(refreshTokenService).deleteRefreshToken(userIdString);
+        verify(userRepository, never()).findById(userId);
+    }
+}

--- a/src/test/java/com/example/seedbe/global/security/jwt/RefreshTokenServiceTest.java
+++ b/src/test/java/com/example/seedbe/global/security/jwt/RefreshTokenServiceTest.java
@@ -1,0 +1,65 @@
+package com.example.seedbe.global.security.jwt;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock
+    private StringRedisTemplate refreshTokenRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Test
+    @DisplayName("refresh token 저장 시 Redis에는 원문 대신 SHA-256 hash가 저장된다.")
+    void saveRefreshTokenStoresHash() {
+        JwtProperties jwtProperties = new JwtProperties("secret", 3_600_000L, 1_209_600_000L);
+        RefreshTokenService refreshTokenService = new RefreshTokenService(refreshTokenRedisTemplate, jwtProperties);
+
+        when(refreshTokenRedisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        String userId = "user-id";
+        String refreshToken = "raw-refresh-token";
+
+        refreshTokenService.saveRefreshToken(userId, refreshToken);
+
+        ArgumentCaptor<String> savedValueCaptor = ArgumentCaptor.forClass(String.class);
+        verify(valueOperations).set(
+                eq("RT:" + userId),
+                savedValueCaptor.capture(),
+                eq(jwtProperties.refreshTokenExpiration()),
+                eq(TimeUnit.MILLISECONDS)
+        );
+
+        String savedValue = savedValueCaptor.getValue();
+        assertThat(savedValue).isNotEqualTo(refreshToken);
+        assertThat(savedValue).hasSize(64);
+        assertThat(refreshTokenService.matchesRefreshTokenHash(savedValue, refreshToken)).isTrue();
+    }
+
+    @Test
+    @DisplayName("저장 hash와 요청 refresh token hash가 다르면 false를 반환한다.")
+    void matchesRefreshTokenHashReturnsFalseWhenTokenDoesNotMatch() {
+        JwtProperties jwtProperties = new JwtProperties("secret", 3_600_000L, 1_209_600_000L);
+        RefreshTokenService refreshTokenService = new RefreshTokenService(refreshTokenRedisTemplate, jwtProperties);
+
+        String savedHash = "0".repeat(64);
+
+        assertThat(refreshTokenService.matchesRefreshTokenHash(savedHash, "different-refresh-token")).isFalse();
+    }
+}


### PR DESCRIPTION
  ## 요약

  - Redis에 refresh token 원문 대신 SHA-256 hash를 저장하도록 변경했습니다.
  - refresh token 재발급 시 요청 token을 hash하여 Redis 저장 hash와 비교하도록 변경했습니다.
  - 저장 hash와 요청 token hash가 불일치하면 reuse 의심으로 보고 Redis refresh token을 삭제하도록 처리했습니다.
  - 기존 cookie path, token expiration, API 응답 흐름은 유지했습니다.
  - 관련 unit test를 추가했습니다.

  ## 배경

  기존 구조에서는 Redis에 refresh token 원문이 그대로 저장됐습니다.

  또한 refresh token rotation 이후 이전 refresh token으로 재발급 요청이 들어오면 단순히 `INVALID_TOKEN`만 반환하고, 현재 Redis refresh session은 유지했습니다.

  이번 변경은 jti 기반 token family/blacklist 전략까지 도입하지 않고, 현재 단일 refresh token 구조를 유지하면서 보안 수준을 한 단계 올리는 목적입니다.

  ## 변경 내용

  - `RefreshTokenService`
    - `saveRefreshToken`
      - refresh token 원문 대신 SHA-256 hash 저장
    - `getRefreshTokenHash`
      - Redis에 저장된 refresh token hash 조회
    - `matchesRefreshTokenHash`
      - 저장 hash와 요청 refresh token hash 비교
    - `deleteRefreshToken`
      - 기존 Redis refresh token 삭제 책임 유지

  - `AuthService`
    - 저장된 refresh token hash가 없으면 기존처럼 `INVALID_TOKEN`
    - 저장 hash와 요청 token hash가 불일치하면 Redis refresh token 삭제 후 `INVALID_TOKEN`

  - Test
    - Redis에 refresh token 원문이 저장되지 않는지 검증
    - 정상 refresh token 재발급 흐름 검증
    - 회전된 이전 refresh token 재사용 의심 시 Redis refresh token 삭제 검증

  ## 검증

  ```bash
  ./gradlew test --tests com.example.seedbe.global.security.jwt.RefreshTokenServiceTest --tests com.example.seedbe.domain.auth.service.AuthServiceTest
```
  통과.
```
  ./gradlew test
```
  전체 테스트 통과.

  ## 참고

  이번 PR에서는 아래 항목은 의도적으로 포함하지 않았습니다.

  - jti claim 추가
  - token family 모델 도입
  - used-token blacklist 저장
  - multi-device refresh session 분리