### PR TITLE
Refactor : 로그추가 및 보안 관련 로직 수정

### DIFF
--- a/src/main/java/com/example/seedbe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/seedbe/domain/auth/service/AuthService.java
@@ -27,7 +27,7 @@ public class AuthService {
 
     @Transactional
     public void reissueToken(String refreshToken, HttpServletResponse response, Boolean isSecure) {
-        if (!jwtProvider.validateToken(refreshToken)) {
+        if (!jwtProvider.validateRefreshToken(refreshToken)) {
             throw new BusinessException(ErrorType.INVALID_TOKEN);
         }
 

--- a/src/main/java/com/example/seedbe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/seedbe/domain/auth/service/AuthService.java
@@ -39,6 +39,7 @@ public class AuthService {
         }
 
         if (!refreshTokenService.matchesRefreshTokenHash(savedRefreshTokenHash, refreshToken)) {
+            log.warn("유저 ID: {} - Refresh Token 재사용 의심으로 세션 삭제", userId);
             refreshTokenService.deleteRefreshToken(userId);
             throw new BusinessException(ErrorType.INVALID_TOKEN);
         }

--- a/src/main/java/com/example/seedbe/global/security/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/seedbe/global/security/jwt/JwtAuthFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String token = resolveTokenFromCookie(request);
 
-        if (token != null && jwtProvider.validateToken(token)) {
+        if (token != null && jwtProvider.validateAccessToken(token)) {
             String userId = jwtProvider.getUserIdFromToken(token);
             UserDetails userDetails = customUserDetailsService.loadUserByUsername(userId);
 

--- a/src/main/java/com/example/seedbe/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/example/seedbe/global/security/jwt/JwtProvider.java
@@ -17,6 +17,10 @@ import java.util.Date;
 @Slf4j
 @Component
 public class JwtProvider {
+    private static final String TOKEN_TYPE_CLAIM = "tokenType";
+    private static final String ACCESS_TOKEN_TYPE = "ACCESS";
+    private static final String REFRESH_TOKEN_TYPE = "REFRESH";
+
     private final SecretKey key;
     private final long accessTokenExpiration;
     private final long refreshTokenExpiration;
@@ -35,6 +39,7 @@ public class JwtProvider {
 
         return Jwts.builder()
                 .subject(userId) // 토큰의 주인 (식별자)
+                .claim(TOKEN_TYPE_CLAIM, ACCESS_TOKEN_TYPE)
                 .claim("role", role) // 권한 정보 추가
                 .issuedAt(now)
                 .expiration(expiryDate)
@@ -49,6 +54,7 @@ public class JwtProvider {
 
         return Jwts.builder()
                 .subject(userId)
+                .claim(TOKEN_TYPE_CLAIM, REFRESH_TOKEN_TYPE)
                 .issuedAt(now)
                 .expiration(expiryDate)
                 .signWith(key)
@@ -57,13 +63,17 @@ public class JwtProvider {
 
     // UserId추출
     public String getUserIdFromToken(String token) {
-        Claims claims = Jwts.parser()
-                .verifyWith(key)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload();
+        Claims claims = parseClaims(token);
 
         return claims.getSubject();
+    }
+
+    public boolean validateAccessToken(String token) {
+        return validateTokenType(token, ACCESS_TOKEN_TYPE);
+    }
+
+    public boolean validateRefreshToken(String token) {
+        return validateTokenType(token, REFRESH_TOKEN_TYPE);
     }
 
     // 토큰 유효성 검증
@@ -83,5 +93,31 @@ public class JwtProvider {
             log.error("JWT 토큰이 잘못되었습니다.", e);
         }
         return false;
+    }
+
+    private boolean validateTokenType(String token, String expectedTokenType) {
+        try {
+            Claims claims = parseClaims(token);
+            return expectedTokenType.equals(claims.get(TOKEN_TYPE_CLAIM, String.class));
+        } catch (SignatureException e) {
+            log.error("잘못된 JWT 서명입니다.", e);
+        } catch (MalformedJwtException e){
+            log.error("유효하지 않은 JWT 토큰입니다.", e);
+        }catch (ExpiredJwtException e) {
+            log.error("만료된 JWT 토큰입니다.", e);
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰입니다.", e);
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 토큰이 잘못되었습니다.", e);
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 }

--- a/src/main/java/com/example/seedbe/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/example/seedbe/global/security/jwt/JwtProvider.java
@@ -77,24 +77,6 @@ public class JwtProvider {
     }
 
     // 토큰 유효성 검증
-    public boolean validateToken(String token) {
-        try {
-            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
-            return true;
-        } catch (SignatureException e) {
-            log.error("잘못된 JWT 서명입니다.", e);
-        } catch (MalformedJwtException e){
-            log.error("유효하지 않은 JWT 토큰입니다.", e);
-        }catch (ExpiredJwtException e) {
-            log.error("만료된 JWT 토큰입니다.", e);
-        } catch (UnsupportedJwtException e) {
-            log.error("지원되지 않는 JWT 토큰입니다.", e);
-        } catch (IllegalArgumentException e) {
-            log.error("JWT 토큰이 잘못되었습니다.", e);
-        }
-        return false;
-    }
-
     private boolean validateTokenType(String token, String expectedTokenType) {
         try {
             Claims claims = parseClaims(token);

--- a/src/main/java/com/example/seedbe/global/security/jwt/RefreshTokenService.java
+++ b/src/main/java/com/example/seedbe/global/security/jwt/RefreshTokenService.java
@@ -34,7 +34,14 @@ public class RefreshTokenService {
     }
 
     public boolean matchesRefreshTokenHash(String savedRefreshTokenHash, String refreshToken) {
-        return savedRefreshTokenHash != null && savedRefreshTokenHash.equals(hashToken(refreshToken));
+        if (savedRefreshTokenHash == null) {
+            return false;
+        }
+
+        byte[] savedRefreshTokenHashBytes = HexFormat.of().parseHex(savedRefreshTokenHash);
+        byte[] requestRefreshTokenHashBytes = HexFormat.of().parseHex(hashToken(refreshToken));
+
+        return MessageDigest.isEqual(savedRefreshTokenHashBytes, requestRefreshTokenHashBytes);
     }
 
     public void deleteRefreshToken(String userId) {

--- a/src/test/java/com/example/seedbe/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/seedbe/domain/auth/service/AuthServiceTest.java
@@ -57,7 +57,7 @@ class AuthServiceTest {
                 .build();
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        when(jwtProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtProvider.validateRefreshToken(refreshToken)).thenReturn(true);
         when(jwtProvider.getUserIdFromToken(refreshToken)).thenReturn(userIdString);
         when(refreshTokenService.getRefreshTokenHash(userIdString)).thenReturn(savedRefreshTokenHash);
         when(refreshTokenService.matchesRefreshTokenHash(savedRefreshTokenHash, refreshToken)).thenReturn(true);
@@ -85,7 +85,7 @@ class AuthServiceTest {
         String rotatedRefreshToken = "rotated-refresh-token";
         String savedRefreshTokenHash = "saved-refresh-token-hash";
 
-        when(jwtProvider.validateToken(rotatedRefreshToken)).thenReturn(true);
+        when(jwtProvider.validateRefreshToken(rotatedRefreshToken)).thenReturn(true);
         when(jwtProvider.getUserIdFromToken(rotatedRefreshToken)).thenReturn(userIdString);
         when(refreshTokenService.getRefreshTokenHash(userIdString)).thenReturn(savedRefreshTokenHash);
         when(refreshTokenService.matchesRefreshTokenHash(savedRefreshTokenHash, rotatedRefreshToken)).thenReturn(false);
@@ -95,5 +95,22 @@ class AuthServiceTest {
 
         verify(refreshTokenService).deleteRefreshToken(userIdString);
         verify(userRepository, never()).findById(userId);
+    }
+
+    @Test
+    @DisplayName("refresh token 타입이 아니면 Redis refresh token을 삭제하지 않는다.")
+    void reissueTokenDoesNotDeleteRefreshTokenWhenTokenIsNotRefreshToken() {
+        JwtProperties jwtProperties = new JwtProperties("secret", 3_600_000L, 1_209_600_000L);
+        AuthService authService = new AuthService(jwtProvider, refreshTokenService, userRepository, jwtProperties);
+
+        String accessToken = "access-token";
+
+        when(jwtProvider.validateRefreshToken(accessToken)).thenReturn(false);
+
+        assertThatThrownBy(() -> authService.reissueToken(accessToken, new MockHttpServletResponse(), true))
+                .isInstanceOf(BusinessException.class);
+
+        verify(jwtProvider, never()).getUserIdFromToken(accessToken);
+        verify(refreshTokenService, never()).deleteRefreshToken(org.mockito.ArgumentMatchers.anyString());
     }
 }

--- a/src/test/java/com/example/seedbe/global/security/jwt/JwtProviderTest.java
+++ b/src/test/java/com/example/seedbe/global/security/jwt/JwtProviderTest.java
@@ -1,0 +1,33 @@
+package com.example.seedbe.global.security.jwt;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtProviderTest {
+
+    private final JwtProvider jwtProvider = new JwtProvider(new JwtProperties(
+            "dGVzdC1zZWNyZXQta2V5LWZvci1qd3QtdG9rZW4tZ2VuZXJhdGlvbi1tdXN0LWJlLWxvbmc=",
+            3_600_000L,
+            1_209_600_000L
+    ));
+
+    @Test
+    @DisplayName("access token은 access token 검증만 통과한다.")
+    void accessTokenPassesOnlyAccessTokenValidation() {
+        String accessToken = jwtProvider.createAccessToken("user-id", "ROLE_USER");
+
+        assertThat(jwtProvider.validateAccessToken(accessToken)).isTrue();
+        assertThat(jwtProvider.validateRefreshToken(accessToken)).isFalse();
+    }
+
+    @Test
+    @DisplayName("refresh token은 refresh token 검증만 통과한다.")
+    void refreshTokenPassesOnlyRefreshTokenValidation() {
+        String refreshToken = jwtProvider.createRefreshToken("user-id");
+
+        assertThat(jwtProvider.validateRefreshToken(refreshToken)).isTrue();
+        assertThat(jwtProvider.validateAccessToken(refreshToken)).isFalse();
+    }
+}


### PR DESCRIPTION
### 변경 내용1
  - JwtProvider
      - JWT 생성 시 tokenType claim 추가
          - Access Token: ACCESS
          - Refresh Token: REFRESH
      - validateAccessToken
      - validateRefreshToken
      - token type 검증 로직 추가
  - AuthService
      - reissue에서 기존 validateToken() 대신 validateRefreshToken() 사용
      - refresh token 타입이 아니면 바로 INVALID_TOKEN
      - 이 경우 Redis 삭제 안 함
  - JwtAuthFilter
      - 인증 필터에서는 validateAccessToken()만 통과
  - 테스트 추가/수정
      - access token이 reissue로 들어오면 Redis 삭제하지 않는 케이스 추가
      - access token / refresh token type 검증 테스트 추가

### 변경 내용2
로그를 추가하였습니다

### 변경 내용3
 refresh token hash 비교 로직을 `String.equals()`에서 `MessageDigest.isEqual()` 기반 비교로 변경했습니다.
 - `savedRefreshTokenHash`가 `null`인 경우는 기존처럼 `false`를 반환하도록 유지했습니다.
 - Redis에는 SHA-256 hash를 hex string으로 저장하고 있으므로, 비교 시 `HexFormat`으로 byte array로 변환한 뒤 `MessageDigest.isEqual()`을 사용하도록 수정했습니다.
  - 관련 테스트와 전체 테스트를 확인했습니다.

### 기타 사항
 병렬 재발급 요청으로 인한 race condition은 현재 단일 refresh token 구조에서 존재할 수 있는 이슈로 확인했습니다. 다만 Redis Lua/CAS, 짧은 grace period, jti 기반 token family 등 설계 선택이 필요한 변경이라 이번 PR 범위에서는 다루지 않고 후속 개선 항목으로 분리하겠습니다.