### PR TITLE
refactor: 프로젝트 생성 시 PDF/Gemini 처리와 DB 트랜잭션 분리

### DIFF
--- a/src/main/java/com/example/seedbe/domain/project/service/PdfService.java
+++ b/src/main/java/com/example/seedbe/domain/project/service/PdfService.java
@@ -16,10 +16,11 @@ import java.util.List;
 @Service
 public class PdfService {
     private static final int MAX_FILE_COUNT = 3;
+    private static final String WHITESPACE_REGEX = "\\s+";
 
-    public String combineTexts(List<MultipartFile> files) {
+    public PdfParseResult parse(List<MultipartFile> files) {
         if (files == null || files.isEmpty()) {
-            return "";
+            return PdfParseResult.empty();
         }
 
         if (files.size() > MAX_FILE_COUNT) {
@@ -32,6 +33,12 @@ public class PdfService {
         for (MultipartFile file : files) {
             String text = extractTextFromPDF(file);
 
+            // 이미지 기반 PDF처럼 텍스트 레이어가 없으면 문서 마커를 붙이지 않는다.
+            if (text.isBlank()) {
+                documentCount++;
+                continue;
+            }
+
             combinedPdfText.append("[문서 ").append(documentCount).append(" 시작]\n")
                     .append(text).append("\n")
                     .append("[문서 ").append(documentCount).append(" 끝]\n\n");
@@ -39,7 +46,7 @@ public class PdfService {
             documentCount++;
         }
 
-        return combinedPdfText.toString();
+        return new PdfParseResult(combinedPdfText.toString().trim());
     }
 
     public String extractTextFromPDF(MultipartFile file) {
@@ -54,10 +61,25 @@ public class PdfService {
                 return ""; // 에러 던지는 대신 빈칸 리턴 (유저 텍스트로 커버 가능하게)
             }
 
-            return text.trim();
+            return normalizeText(text);
         } catch (IOException e) {
             log.error("PDF 파싱 에러", e);
             throw new BusinessException(ErrorType.PDF_PARSING_FAILED);
+        }
+    }
+
+    private String normalizeText(String text) {
+        // PDFBox 추출 텍스트의 과도한 줄바꿈/공백을 Gemini 입력 전에 최소 정리한다.
+        return text.replaceAll(WHITESPACE_REGEX, " ").trim();
+    }
+
+    public record PdfParseResult(String text) {
+        public static PdfParseResult empty() {
+            return new PdfParseResult("");
+        }
+
+        public boolean hasExtractedText() {
+            return !text.isBlank();
         }
     }
 }

--- a/src/main/java/com/example/seedbe/domain/project/service/PdfService.java
+++ b/src/main/java/com/example/seedbe/domain/project/service/PdfService.java
@@ -11,12 +11,13 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 public class PdfService {
     private static final int MAX_FILE_COUNT = 3;
-    private static final String WHITESPACE_REGEX = "\\s+";
+    private static final String HORIZONTAL_WHITESPACE_REGEX = "[ \\t\\x0B\\f]+";
 
     public PdfParseResult parse(List<MultipartFile> files) {
         if (files == null || files.isEmpty()) {
@@ -69,8 +70,13 @@ public class PdfService {
     }
 
     private String normalizeText(String text) {
-        // PDFBox 추출 텍스트의 과도한 줄바꿈/공백을 Gemini 입력 전에 최소 정리한다.
-        return text.replaceAll(WHITESPACE_REGEX, " ").trim();
+        // 줄바꿈은 문단/목록 구조이므로 유지하고, 같은 줄 안의 과도한 공백만 줄인다.
+        return text.replace("\r\n", "\n")
+                .replace('\r', '\n')
+                .lines()
+                .map(line -> line.replaceAll(HORIZONTAL_WHITESPACE_REGEX, " ").trim())
+                .collect(Collectors.joining("\n"))
+                .trim();
     }
 
     public record PdfParseResult(String text) {

--- a/src/main/java/com/example/seedbe/domain/project/service/PdfService.java
+++ b/src/main/java/com/example/seedbe/domain/project/service/PdfService.java
@@ -11,13 +11,13 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 public class PdfService {
     private static final int MAX_FILE_COUNT = 3;
-    private static final String HORIZONTAL_WHITESPACE_REGEX = "[ \\t\\x0B\\f]+";
+    private static final String HORIZONTAL_WHITESPACE = "[ \\t]+";
+    private static final String VERTICAL_WHITESPACE = "(\\r\\n|\\r|\\n)+";
 
     public PdfParseResult parse(List<MultipartFile> files) {
         if (files == null || files.isEmpty()) {
@@ -71,11 +71,8 @@ public class PdfService {
 
     private String normalizeText(String text) {
         // 줄바꿈은 문단/목록 구조이므로 유지하고, 같은 줄 안의 과도한 공백만 줄인다.
-        return text.replace("\r\n", "\n")
-                .replace('\r', '\n')
-                .lines()
-                .map(line -> line.replaceAll(HORIZONTAL_WHITESPACE_REGEX, " ").trim())
-                .collect(Collectors.joining("\n"))
+        return text.replaceAll(HORIZONTAL_WHITESPACE, " ")
+                .replaceAll(VERTICAL_WHITESPACE, "\n")
                 .trim();
     }
 

--- a/src/main/java/com/example/seedbe/domain/project/service/ProjectService.java
+++ b/src/main/java/com/example/seedbe/domain/project/service/ProjectService.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.Map;
@@ -24,37 +25,51 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ProjectService {
     private final ProjectValidator projectValidator;
     private final ProjectRepository projectRepository;
     private final ProjectStepLogRepository stepLogRepository;
     private final PdfService pdfService;
     private final AIService aiService;
+    private final TransactionTemplate transactionTemplate;
 
+    @Transactional(readOnly = true)
     public Page<ProjectListResponse> getProjects(UUID userId, ProjectStatus status, Pageable pageable) {
         Page<Project> projectPage = projectRepository.findByUserIdAndStatus(userId, status, pageable);
         return projectPage.map(ProjectListResponse::from);
     }
 
+    @Transactional(readOnly = true)
     public ProjectDetailResponse getProjectDetails(UUID userId, UUID projectId) {
         Project project = projectValidator.getProjectWithOwnershipCheck(userId, projectId);
         List<ProjectStepLog> stepLogs = stepLogRepository.findByProjectOrderByCreatedAtAsc(project);
         return ProjectDetailResponse.of(project, stepLogs);
     }
 
-    @Transactional
     public ProjectDetailResponse createProject(User user, ProjectCreateRequest projectCreateRequest) {
-        // pdf 텍스트화
-        String finalPdfText = pdfService.combineTexts(projectCreateRequest.files());
+        // PDF parsing과 Gemini 호출은 DB transaction 밖에서 먼저 끝낸다.
+        PdfService.PdfParseResult pdfParseResult = pdfService.parse(projectCreateRequest.files());
+        String userIntent = projectCreateRequest.userIntent();
 
-        if (finalPdfText.isEmpty() && projectCreateRequest.userIntent().isBlank()) {
+        if (!pdfParseResult.hasExtractedText() && (userIntent == null || userIntent.isBlank())) {
             throw new BusinessException(ErrorType.NO_CONTENT_TO_ANALYZE);
         }
 
-        // ai를 활용한 프롬프트 변수추출
-        Map<String, Object> extractedVariables = aiService.analyzeToJSON(finalPdfText, projectCreateRequest.userIntent(), projectCreateRequest.roadmapType());
+        Map<String, Object> extractedVariables = aiService.analyzeToJSON(
+                pdfParseResult.text(),
+                userIntent,
+                projectCreateRequest.roadmapType()
+        );
 
+        // 외부 I/O가 끝난 뒤, 실제 DB write 구간만 짧게 transaction으로 묶는다.
+        return transactionTemplate.execute(status -> saveProject(user, projectCreateRequest, extractedVariables));
+    }
+
+    private ProjectDetailResponse saveProject(
+            User user,
+            ProjectCreateRequest projectCreateRequest,
+            Map<String, Object> extractedVariables
+    ) {
         Project project = Project.builder()
                 .user(user)
                 .title(projectCreateRequest.title())

--- a/src/test/java/com/example/seedbe/domain/project/service/PdfServiceTest.java
+++ b/src/test/java/com/example/seedbe/domain/project/service/PdfServiceTest.java
@@ -1,0 +1,65 @@
+package com.example.seedbe.domain.project.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PdfServiceTest {
+
+    private final PdfService pdfService = new PdfService();
+
+    @Test
+    @DisplayName("PDF 텍스트 정규화 시 줄바꿈은 유지하고 가로 공백만 줄인다.")
+    void parsePreservesLineBreaksAndNormalizesHorizontalWhitespace() throws IOException {
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                "assignment.pdf",
+                "application/pdf",
+                createPdf("""
+                        first    line
+                        second    line
+                        """)
+        );
+
+        PdfService.PdfParseResult result = pdfService.parse(List.of(file));
+
+        assertThat(result.text()).contains("first line\nsecond line");
+        assertThat(result.text()).doesNotContain("first line second line");
+        assertThat(result.text()).doesNotContain("    ");
+    }
+
+    private byte[] createPdf(String text) throws IOException {
+        try (PDDocument document = new PDDocument();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                contentStream.beginText();
+                contentStream.setFont(PDType1Font.HELVETICA, 12);
+                contentStream.newLineAtOffset(50, 700);
+
+                for (String line : text.split("\\R", -1)) {
+                    contentStream.showText(line);
+                    contentStream.newLineAtOffset(0, -16);
+                }
+
+                contentStream.endText();
+            }
+
+            document.save(outputStream);
+            return outputStream.toByteArray();
+        }
+    }
+}

--- a/src/test/java/com/example/seedbe/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/example/seedbe/domain/project/service/ProjectServiceTest.java
@@ -1,0 +1,143 @@
+package com.example.seedbe.domain.project.service;
+
+import com.example.seedbe.domain.project.component.ProjectValidator;
+import com.example.seedbe.domain.project.dto.ProjectCreateRequest;
+import com.example.seedbe.domain.project.dto.ProjectDetailResponse;
+import com.example.seedbe.domain.project.entity.Project;
+import com.example.seedbe.domain.project.enums.ProjectStatus;
+import com.example.seedbe.domain.project.enums.RoadmapType;
+import com.example.seedbe.domain.project.repository.ProjectRepository;
+import com.example.seedbe.domain.project.repository.ProjectStepLogRepository;
+import com.example.seedbe.domain.user.entity.User;
+import com.example.seedbe.domain.user.enums.Role;
+import com.example.seedbe.global.exception.BusinessException;
+import com.example.seedbe.global.exception.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @Mock
+    private ProjectValidator projectValidator;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private ProjectStepLogRepository stepLogRepository;
+
+    @Mock
+    private PdfService pdfService;
+
+    @Mock
+    private AIService aiService;
+
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
+    @Mock
+    private TransactionStatus transactionStatus;
+
+    @Test
+    @DisplayName("PDF와 사용자 입력이 모두 비어 있으면 Gemini 호출과 DB 저장을 수행하지 않는다.")
+    void createProjectDoesNotCallAiOrSaveWhenThereIsNoContentToAnalyze() {
+        ProjectService projectService = createProjectService();
+        ProjectCreateRequest request = new ProjectCreateRequest("title", RoadmapType.REPORT, "", null);
+
+        when(pdfService.parse(request.files())).thenReturn(PdfService.PdfParseResult.empty());
+
+        assertThatThrownBy(() -> projectService.createProject(createUser(), request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.NO_CONTENT_TO_ANALYZE);
+
+        verify(aiService, never()).analyzeToJSON(any(), any(), any());
+        verify(projectRepository, never()).save(any(Project.class));
+    }
+
+    @Test
+    @DisplayName("Gemini 호출이 실패하면 DB 저장을 수행하지 않는다.")
+    void createProjectDoesNotSaveWhenAiAnalysisFails() {
+        ProjectService projectService = createProjectService();
+        ProjectCreateRequest request = new ProjectCreateRequest("title", RoadmapType.REPORT, "요구사항", null);
+
+        when(pdfService.parse(request.files())).thenReturn(new PdfService.PdfParseResult("PDF 텍스트"));
+        when(aiService.analyzeToJSON("PDF 텍스트", "요구사항", RoadmapType.REPORT))
+                .thenThrow(new BusinessException(ErrorType.AI_SERVER_ERROR));
+
+        assertThatThrownBy(() -> projectService.createProject(createUser(), request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.AI_SERVER_ERROR);
+
+        verify(projectRepository, never()).save(any(Project.class));
+    }
+
+    @Test
+    @DisplayName("PDF/Gemini 처리가 성공한 뒤 DB 저장 구간만 transaction으로 실행한다.")
+    void createProjectSavesProjectInsideTransactionAfterIoWorkSucceeds() {
+        ProjectService projectService = createProjectService();
+        ProjectCreateRequest request = new ProjectCreateRequest("title", RoadmapType.REPORT, "요구사항", null);
+        Map<String, Object> extractedVariables = Map.of("topic", "테스트 주제");
+
+        when(pdfService.parse(request.files())).thenReturn(new PdfService.PdfParseResult("PDF 텍스트"));
+        when(aiService.analyzeToJSON("PDF 텍스트", "요구사항", RoadmapType.REPORT)).thenReturn(extractedVariables);
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(transactionStatus);
+        });
+        when(projectRepository.save(any(Project.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ProjectDetailResponse response = projectService.createProject(createUser(), request);
+
+        ArgumentCaptor<Project> projectCaptor = ArgumentCaptor.forClass(Project.class);
+        verify(transactionTemplate).execute(any());
+        verify(projectRepository).save(projectCaptor.capture());
+
+        Project savedProject = projectCaptor.getValue();
+        assertThat(savedProject.getTitle()).isEqualTo("title");
+        assertThat(savedProject.getRoadmapType()).isEqualTo(RoadmapType.REPORT);
+        assertThat(savedProject.getStatus()).isEqualTo(ProjectStatus.IN_PROGRESS);
+        assertThat(savedProject.getInitialContext()).isEqualTo(extractedVariables);
+        assertThat(response.title()).isEqualTo("title");
+    }
+
+    private ProjectService createProjectService() {
+        return new ProjectService(
+                projectValidator,
+                projectRepository,
+                stepLogRepository,
+                pdfService,
+                aiService,
+                transactionTemplate
+        );
+    }
+
+    private User createUser() {
+        return User.builder()
+                .provider("google")
+                .providerId("provider-id")
+                .email("seed@example.com")
+                .nickname("seed")
+                .role(Role.ROLE_USER)
+                .profileUrl("https://example.com/profile.png")
+                .build();
+    }
+}


### PR DESCRIPTION
  ## 요약

  - 프로젝트 생성 흐름에서 PDF parsing, Gemini API 호출을 DB transaction 밖으로 분리했습니다.
  - 실제 DB 저장 구간만 `TransactionTemplate`으로 짧게 transaction 처리하도록 변경했습니다.
  - PDF parsing 결과를 `PdfParseResult`로 명확히 표현하도록 정리했습니다.
  - 텍스트 추출이 되지 않는 이미지 기반 PDF는 빈 문서 마커를 Gemini 입력에 포함하지 않도록 변경했습니다.
  - PDFBox 추출 텍스트의 과도한 공백/줄바꿈을 최소 정규화했습니다.
  - 프로젝트 생성 실패 케이스에 대한 service test를 추가했습니다.

  ## 배경

  기존 `ProjectService.createProject`는 `@Transactional` 내부에서 다음 작업을 모
  두 수행했습니다.

  ```text
  PDF parsing
  Gemini API 호출
  Project DB 저장
  ```

  이 구조에서는 PDF parsing 또는 Gemini API 지연/실패가 DB transaction에 직접 영향을 줍니다.

  특히 Raspberry Pi 운영 환경에서는 긴 transaction이 DB connection 점유와 리소스 부담으로 이어질 수 있어, 외부 I/O 작업과 DB write 책임을 분리할 필요가 있었습니다.

  또한 기존 PDF parsing은 텍스트 추출에 실패한 이미지 기반 PDF도 빈 문서 마커를 붙일 수 있어, 실제 분석 가능한 텍스트가 있는지 판단이 불명확했습니다.

  ## 변경 내용

  ### ProjectService

  - createProject에서 @Transactional 제거
  - PDF parsing과 Gemini API 호출을 transaction 밖에서 수행
  - Gemini 분석이 성공한 이후에만 DB 저장 수행
  - DB 저장 구간만 TransactionTemplate으로 감싸 transaction 범위 최소화

  변경 후 흐름:

  1. PDF parsing
  2. 분석할 텍스트/userIntent 존재 여부 확인
  3. Gemini API 호출
  4. DB transaction 시작
  5. Project 저장
  6. DB transaction 종료

  ### PdfService

  - 기존 combineTexts() 제거
  - parse()가 PdfParseResult를 반환하도록 변경
  - 텍스트 추출 실패 PDF는 Gemini 입력에 빈 문서 마커를 추가하지 않도록 처리
  - PDFBox 추출 텍스트에 대해 whitespace 정규화 추가

  ```
  public record PdfParseResult(String text) {
      public static PdfParseResult empty() {
          return new PdfParseResult("");
      }

      public boolean hasExtractedText() {
          return !text.isBlank();
      }
  }
  ```

  ### 실패 처리 정책

  이번 PR에서는 기존 API 응답 동작을 유지했습니다.

  - PDF parsing 실패
      - 기존처럼 PDF_PARSING_FAILED
      - Project 저장 안 함
  - PDF 텍스트 없음 + userIntent 없음
      - 기존처럼 NO_CONTENT_TO_ANALYZE
      - Project 저장 안 함
  - Gemini 호출/응답 파싱 실패
      - 기존처럼 AI_SERVER_ERROR 또는 AI_RESPONSE_PARSE_ERROR
      - Project 저장 안 함
  - Gemini 분석 성공
      - 짧은 DB transaction 안에서 Project 저장

  FAILED 상태 저장, 실패 사유 컬럼, 재시도 API는 상태/응답 정책 변경이 필요하므로 이번 PR 범위에서는 제외했습니다.

  ## 테스트

  추가:

  src/test/java/com/example/seedbe/domain/project/service/ProjectServiceTest.java

  검증한 내용:

  - PDF와 userIntent가 모두 비어 있으면 Gemini 호출과 DB 저장을 수행하지 않음
  - Gemini 호출이 실패하면 DB 저장을 수행하지 않음
  - PDF/Gemini 처리가 성공한 뒤 DB 저장 구간만 transaction으로 실행됨

  ## 검증

  ```
  ./gradlew test --tests
  com.example.seedbe.domain.project.service.ProjectServiceTest
  ```
  통과.

  ## 참고

  이번 PR에서는 OCR은 도입하지 않았습니다.

  현재 PDF 처리는 PDFBox의 PDFTextStripper 기반 텍스트 레이어 추출만 지원합니다.
  스캔본/이미지 기반 PDF의 텍스트 인식은 Tesseract, Vision API, Gemini multimodal등 별도 설계가 필요하므로 후속 이슈로 분리하는 것이 적절합니다.