### PR TITLE
feature: 이미지 기반 PDF 처리를 위한 Tesseract OCR 지원

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,13 @@ ENV LC_ALL=C.UTF-8
 
 WORKDIR /app
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        tesseract-ocr \
+        tesseract-ocr-eng \
+        tesseract-ocr-kor && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN groupadd -r ${GROUP} && \
     useradd -r -g ${GROUP} -s /bin/false ${USER}
 

--- a/src/main/java/com/example/seedbe/domain/project/component/pdf/PdfDocumentTextExtractor.java
+++ b/src/main/java/com/example/seedbe/domain/project/component/pdf/PdfDocumentTextExtractor.java
@@ -1,0 +1,72 @@
+package com.example.seedbe.domain.project.component.pdf;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class PdfDocumentTextExtractor {
+    private static final int MAX_OCR_PAGE_COUNT_PER_FILE = 10;
+
+    private final PdfImageDetector pdfImageDetector;
+    private final TesseractOcrClient tesseractOcrClient;
+    private final PdfTextNormalizer textNormalizer;
+
+    public String extract(PDDocument document) throws IOException {
+        PDFTextStripper pdfStripper = new PDFTextStripper();
+        PDFRenderer pdfRenderer = new PDFRenderer(document);
+        StringBuilder documentText = new StringBuilder();
+        int ocrPageCount = 0;
+
+        for (int pageIndex = 0; pageIndex < document.getNumberOfPages(); pageIndex++) {
+            int pageNumber = pageIndex + 1;
+            String pageText = extractPageText(pdfStripper, document, pageNumber);
+            PDPage page = document.getPage(pageIndex);
+
+            // 이미지가 포함된 페이지는 캡처/스캔 텍스트 누락 가능성이 있어 OCR을 병행한다.
+            if (pdfImageDetector.hasImage(page) && ocrPageCount < MAX_OCR_PAGE_COUNT_PER_FILE) {
+                String ocrText = tesseractOcrClient.extractText(pdfRenderer, pageIndex);
+                pageText = mergePageText(pageText, ocrText);
+                ocrPageCount++;
+            }
+
+            appendPageText(documentText, pageNumber, pageText);
+        }
+
+        return documentText.toString().trim();
+    }
+
+    private String extractPageText(PDFTextStripper pdfStripper, PDDocument document, int pageNumber) throws IOException {
+        pdfStripper.setStartPage(pageNumber);
+        pdfStripper.setEndPage(pageNumber);
+        return textNormalizer.normalize(pdfStripper.getText(document));
+    }
+
+    private String mergePageText(String pageText, String ocrText) {
+        if (ocrText.isBlank()) {
+            return pageText;
+        }
+
+        if (pageText.isBlank()) {
+            return ocrText;
+        }
+
+        return pageText + "\n[OCR 텍스트]\n" + ocrText;
+    }
+
+    private void appendPageText(StringBuilder documentText, int pageNumber, String pageText) {
+        if (pageText.isBlank()) {
+            return;
+        }
+
+        documentText.append("[페이지 ").append(pageNumber).append("]\n")
+                .append(pageText)
+                .append("\n\n");
+    }
+}

--- a/src/main/java/com/example/seedbe/domain/project/component/pdf/PdfDocumentTextExtractor.java
+++ b/src/main/java/com/example/seedbe/domain/project/component/pdf/PdfDocumentTextExtractor.java
@@ -22,6 +22,8 @@ public class PdfDocumentTextExtractor {
         PDFTextStripper pdfStripper = new PDFTextStripper();
         PDFRenderer pdfRenderer = new PDFRenderer(document);
         StringBuilder documentText = new StringBuilder();
+
+        pdfStripper.setSortByPosition(true);
         int ocrPageCount = 0;
 
         for (int pageIndex = 0; pageIndex < document.getNumberOfPages(); pageIndex++) {

--- a/src/main/java/com/example/seedbe/domain/project/component/pdf/PdfImageDetector.java
+++ b/src/main/java/com/example/seedbe/domain/project/component/pdf/PdfImageDetector.java
@@ -1,0 +1,37 @@
+package com.example.seedbe.domain.project.component.pdf;
+
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.graphics.PDXObject;
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class PdfImageDetector {
+
+    public boolean hasImage(PDPage page) throws IOException {
+        return hasImage(page.getResources());
+    }
+
+    private boolean hasImage(PDResources resources) throws IOException {
+        if (resources == null) {
+            return false;
+        }
+
+        for (COSName name : resources.getXObjectNames()) {
+            PDXObject xObject = resources.getXObject(name);
+            if (xObject instanceof PDImageXObject) {
+                return true;
+            }
+            if (xObject instanceof PDFormXObject form && hasImage(form.getResources())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/example/seedbe/domain/project/component/pdf/PdfTextNormalizer.java
+++ b/src/main/java/com/example/seedbe/domain/project/component/pdf/PdfTextNormalizer.java
@@ -1,0 +1,20 @@
+package com.example.seedbe.domain.project.component.pdf;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PdfTextNormalizer {
+    private static final String HORIZONTAL_WHITESPACE = "[ \\t]+";
+    private static final String VERTICAL_WHITESPACE = "(\\r\\n|\\r|\\n)+";
+
+    public String normalize(String text) {
+        if (text == null) {
+            return "";
+        }
+
+        // 줄바꿈은 문단/목록 구조이므로 유지하고, 같은 줄 안의 과도한 공백만 줄인다.
+        return text.replaceAll(HORIZONTAL_WHITESPACE, " ")
+                .replaceAll(VERTICAL_WHITESPACE, "\n")
+                .trim();
+    }
+}

--- a/src/main/java/com/example/seedbe/domain/project/component/pdf/TesseractOcrClient.java
+++ b/src/main/java/com/example/seedbe/domain/project/component/pdf/TesseractOcrClient.java
@@ -1,0 +1,103 @@
+package com.example.seedbe.domain.project.component.pdf;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.springframework.stereotype.Component;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TesseractOcrClient {
+    private static final int OCR_DPI = 200;
+    private static final Duration OCR_TIMEOUT = Duration.ofSeconds(30);
+    private static final String TESSERACT_COMMAND = "tesseract";
+    private static final String TESSERACT_LANGUAGE = "kor+eng";
+
+    private final PdfTextNormalizer textNormalizer;
+
+    public String extractText(PDFRenderer pdfRenderer, int pageIndex) {
+        Path tempDirectory = null;
+
+        try {
+            tempDirectory = Files.createTempDirectory("seed-pdf-ocr-");
+            Path imagePath = tempDirectory.resolve("page.png");
+            Path outputPath = tempDirectory.resolve("ocr-output");
+            Path logPath = tempDirectory.resolve("tesseract.log");
+
+            renderPageImage(pdfRenderer, pageIndex, imagePath);
+            Process process = startTesseract(imagePath, outputPath, logPath);
+
+            if (!process.waitFor(OCR_TIMEOUT.toSeconds(), TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                log.warn("PDF OCR timeout. pageIndex: {}", pageIndex);
+                return "";
+            }
+
+            if (process.exitValue() != 0) {
+                String tesseractLog = Files.exists(logPath) ? Files.readString(logPath) : "";
+                log.warn("PDF OCR failed. pageIndex: {}, output: {}", pageIndex, tesseractLog);
+                return "";
+            }
+
+            return readOcrText(outputPath);
+        } catch (IOException e) {
+            log.warn("PDF OCR 실행 실패. tesseract 설치 또는 이미지 렌더링 상태를 확인해야 합니다.", e);
+            return "";
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("PDF OCR interrupted. pageIndex: {}", pageIndex, e);
+            return "";
+        } finally {
+            deleteTempDirectory(tempDirectory);
+        }
+    }
+
+    private void renderPageImage(PDFRenderer pdfRenderer, int pageIndex, Path imagePath) throws IOException {
+        BufferedImage pageImage = pdfRenderer.renderImageWithDPI(pageIndex, OCR_DPI, ImageType.RGB);
+        ImageIO.write(pageImage, "png", imagePath.toFile());
+    }
+
+    private Process startTesseract(Path imagePath, Path outputPath, Path logPath) throws IOException {
+        return new ProcessBuilder(
+                TESSERACT_COMMAND,
+                imagePath.toString(),
+                outputPath.toString(),
+                "-l",
+                TESSERACT_LANGUAGE,
+                "--psm",
+                "6"
+        ).redirectErrorStream(true)
+                .redirectOutput(logPath.toFile())
+                .start();
+    }
+
+    private String readOcrText(Path outputPath) throws IOException {
+        Path ocrTextPath = Path.of(outputPath + ".txt");
+        String ocrText = Files.exists(ocrTextPath) ? Files.readString(ocrTextPath) : "";
+        return textNormalizer.normalize(ocrText);
+    }
+
+    private void deleteTempDirectory(Path tempDirectory) {
+        if (tempDirectory == null) {
+            return;
+        }
+
+        try (var paths = Files.walk(tempDirectory)) {
+            for (Path path : paths.sorted((left, right) -> right.compareTo(left)).toList()) {
+                Files.deleteIfExists(path);
+            }
+        } catch (IOException e) {
+            log.warn("임시 OCR 파일 삭제 실패. path: {}", tempDirectory, e);
+        }
+    }
+}

--- a/src/main/java/com/example/seedbe/domain/project/component/pdf/TesseractOcrClient.java
+++ b/src/main/java/com/example/seedbe/domain/project/component/pdf/TesseractOcrClient.java
@@ -75,7 +75,7 @@ public class TesseractOcrClient {
                 "-l",
                 TESSERACT_LANGUAGE,
                 "--psm",
-                "6"
+                "3"
         ).redirectErrorStream(true)
                 .redirectOutput(logPath.toFile())
                 .start();

--- a/src/main/java/com/example/seedbe/domain/project/service/PdfService.java
+++ b/src/main/java/com/example/seedbe/domain/project/service/PdfService.java
@@ -2,9 +2,10 @@ package com.example.seedbe.domain.project.service;
 
 import com.example.seedbe.global.exception.BusinessException;
 import com.example.seedbe.global.exception.ErrorType;
+import com.example.seedbe.domain.project.component.pdf.PdfDocumentTextExtractor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.text.PDFTextStripper;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -14,10 +15,11 @@ import java.util.List;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class PdfService {
     private static final int MAX_FILE_COUNT = 3;
-    private static final String HORIZONTAL_WHITESPACE = "[ \\t]+";
-    private static final String VERTICAL_WHITESPACE = "(\\r\\n|\\r|\\n)+";
+
+    private final PdfDocumentTextExtractor pdfDocumentTextExtractor;
 
     public PdfParseResult parse(List<MultipartFile> files) {
         if (files == null || files.isEmpty()) {
@@ -54,26 +56,17 @@ public class PdfService {
         try (InputStream inputStream = file.getInputStream();
              PDDocument document = PDDocument.load(inputStream)){
 
-            PDFTextStripper pdfStripper = new PDFTextStripper();
-            String text = pdfStripper.getText(document);
-
-            if (text == null || text.trim().isEmpty()) {
-                log.warn("이미지 PDF 의심: 텍스트 추출 불가");
-                return ""; // 에러 던지는 대신 빈칸 리턴 (유저 텍스트로 커버 가능하게)
+            String text = pdfDocumentTextExtractor.extract(document);
+            if (text.isBlank()) {
+                log.warn("PDF에서 분석 가능한 텍스트를 추출하지 못했습니다.");
+                return "";
             }
 
-            return normalizeText(text);
+            return text;
         } catch (IOException e) {
             log.error("PDF 파싱 에러", e);
             throw new BusinessException(ErrorType.PDF_PARSING_FAILED);
         }
-    }
-
-    private String normalizeText(String text) {
-        // 줄바꿈은 문단/목록 구조이므로 유지하고, 같은 줄 안의 과도한 공백만 줄인다.
-        return text.replaceAll(HORIZONTAL_WHITESPACE, " ")
-                .replaceAll(VERTICAL_WHITESPACE, "\n")
-                .trim();
     }
 
     public record PdfParseResult(String text) {

--- a/src/test/java/com/example/seedbe/domain/project/service/PdfServiceTest.java
+++ b/src/test/java/com/example/seedbe/domain/project/service/PdfServiceTest.java
@@ -1,65 +1,30 @@
 package com.example.seedbe.domain.project.service;
 
+import com.example.seedbe.domain.project.component.pdf.PdfTextNormalizer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockMultipartFile;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.List;
-
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDPageContentStream;
-import org.apache.pdfbox.pdmodel.font.PDType1Font;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PdfServiceTest {
 
-    private final PdfService pdfService = new PdfService();
+    private final PdfTextNormalizer textNormalizer = new PdfTextNormalizer();
 
     @Test
     @DisplayName("PDF 텍스트 정규화 시 줄바꿈은 유지하고 가로 공백만 줄인다.")
-    void parsePreservesLineBreaksAndNormalizesHorizontalWhitespace() throws IOException {
-        MockMultipartFile file = new MockMultipartFile(
-                "files",
-                "assignment.pdf",
-                "application/pdf",
-                createPdf("""
-                        first    line
-                        second    line
-                        """)
-        );
+    void normalizePreservesLineBreaksAndNormalizesHorizontalWhitespace() {
+        String text = """
+                first    line
+                second\t\tline
 
-        PdfService.PdfParseResult result = pdfService.parse(List.of(file));
+                third      line
+                """;
 
-        assertThat(result.text()).contains("first line\nsecond line");
-        assertThat(result.text()).doesNotContain("first line second line");
-        assertThat(result.text()).doesNotContain("    ");
-    }
+        String normalizedText = textNormalizer.normalize(text);
 
-    private byte[] createPdf(String text) throws IOException {
-        try (PDDocument document = new PDDocument();
-             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-            PDPage page = new PDPage();
-            document.addPage(page);
-
-            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
-                contentStream.beginText();
-                contentStream.setFont(PDType1Font.HELVETICA, 12);
-                contentStream.newLineAtOffset(50, 700);
-
-                for (String line : text.split("\\R", -1)) {
-                    contentStream.showText(line);
-                    contentStream.newLineAtOffset(0, -16);
-                }
-
-                contentStream.endText();
-            }
-
-            document.save(outputStream);
-            return outputStream.toByteArray();
-        }
+        assertThat(normalizedText).contains("first line\nsecond line");
+        assertThat(normalizedText).contains("\nthird line");
+        assertThat(normalizedText).doesNotContain("first line second line");
+        assertThat(normalizedText).doesNotContain("    ");
     }
 }


### PR DESCRIPTION
   ## 요약

  - 이미지가 포함된 PDF 페이지에 대해 Tesseract OCR을 병행하도록 추가했습니다.
  - 기존 PDFBox 텍스트 추출 흐름은 유지하면서, 이미지 페이지에 한해 OCR 결과를 병합합니다.
  - PDF/OCR 처리 로직을 `component/pdf` 패키지로 분리해 `PdfService`의 책임을 줄였습니다.
  - Docker image에 Tesseract OCR 및 한글/영문 언어팩 설치를 추가했습니다.
  - PDF 텍스트 정규화 로직은 줄바꿈을 유지하고 가로 공백만 정리하도록 유지했습니다.

  ## 배경

  기존 PDF parsing은 PDFBox `PDFTextStripper` 기반으로 PDF 내부 텍스트 레이어만 추출했습니다.

  이 방식은 다음 PDF에서 한계가 있었습니다.

  ```text
  - 스캔본 PDF
  - 캡처 이미지 기반 PDF
  - 이미지 안에 표/문제/조건이 포함된 PDF
  - 텍스트와 이미지가 혼합된 과제 PDF
  ```

  텍스트 레이어가 없는 이미지 영역은 PDFBox로 읽을 수 없기 때문에, 실제 과제 내용이 존재해도 Gemini 분
  석에 반영되지 않을 수 있었습니다.

  ## 변경 내용

  ### Dockerfile

  Tesseract OCR 실행에 필요한 패키지를 Docker image에 설치하도록 추가했습니다.

  tesseract-ocr
  tesseract-ocr-eng
  tesseract-ocr-kor

  ### PdfService

  PdfService는 facade 역할만 담당하도록 단순화했습니다.

  - 파일 개수 검증
  - PDF 파일 열기
  - 여러 PDF 결과 결합
  - 문서 단위 마커 추가

  PDF 내부 처리 세부 로직은 별도 컴포넌트로 분리했습니다.

  ### component/pdf 패키지 추가

  domain/project/component/pdf

  추가된 컴포넌트:

  PdfDocumentTextExtractor
  - PDF 페이지 순회
  - PDFBox 텍스트 추출
  - 이미지 페이지 OCR 병합
  - 페이지 단위 마커 추가

  PdfImageDetector
  - PDF 페이지 리소스에서 이미지 포함 여부 확인
  - Form XObject 내부 이미지도 재귀적으로 확인

  TesseractOcrClient
  - PDF 페이지를 이미지로 렌더링
  - Tesseract process 실행
  - OCR 결과 파일 읽기
  - 임시 파일 정리
  - timeout 처리

  PdfTextNormalizer
  - 줄바꿈은 유지
  - 같은 줄 안의 과도한 가로 공백만 정리

  ## 처리 흐름

  변경 후 PDF parsing 흐름은 다음과 같습니다.

  1. PdfService가 업로드 PDF 파일을 연다.
  2. PdfDocumentTextExtractor가 PDF를 페이지 단위로 순회한다.
  3. 각 페이지에서 PDFBox로 텍스트 레이어를 추출한다.
  4. 페이지에 이미지가 포함되어 있으면 Tesseract OCR을 병행한다.
  5. PDFBox 텍스트와 OCR 텍스트를 병합한다.
  6. 페이지별 텍스트를 문서 텍스트로 합친다.
  7. 기존 Project 생성/Gemini 분석 흐름으로 전달한다.

  ## OCR 정책

  초기 구현에서는 정확도와 성능 사이의 균형을 위해 다음 제한을 둡니다.

  - 이미지가 포함된 페이지에만 OCR 적용
  - 파일당 OCR 최대 10페이지
  - 페이지 OCR timeout 30초
  - OCR 렌더링 DPI 200
  - OCR 언어: kor+eng

  이미지 PDF 또는 텍스트/이미지 혼합 PDF에서 누락될 수 있는 이미지 내부 텍스트를 보완하는 것이 목적입니다.

  ## 실패 처리

  OCR 실패가 전체 PDF parsing 실패로 이어지지 않도록 했습니다.

  - PDFBox 텍스트가 있으면 PDFBox 텍스트만 사용
  - OCR 실패 시 WARN 로그 후 빈 OCR 결과로 처리
  - PDFBox와 OCR 모두 텍스트를 얻지 못하면 해당 PDF는 빈 텍스트로 처리

  즉, OCR은 보완 수단이고 기존 텍스트 기반 PDF 처리 흐름은 유지됩니다.

  ## 테스트

  기존 PDF parsing 관련 테스트를 유지/조정했습니다.

  ./gradlew test --tests com.example.seedbe.domain.project.service.PdfServiceTest --tests
  com.example.seedbe.domain.project.service.ProjectServiceTest

  ./gradlew test

  위 테스트는 패키지 분리 이후 통과 확인했습니다.

  마지막 로그 문구 수정 후 테스트 재실행은 중간에 중단했지만, 로직 변경 없이 메시지만 변경한 상태입니
  다.

  ## 참고

  로컬 환경에는 tesseract binary가 없을 수 있습니다.
  실제 OCR 동작은 Docker image 안에서 설치되는 Tesseract 기준으로 확인해야 합니다.

  운영 배포 후 이미지 기반 PDF로 다음 항목을 확인하는 것이 필요합니다.

  - 한글 OCR 품질
  - Raspberry Pi에서 OCR 처리 시간
  - OCR timeout 발생 여부
  - 이미지 많은 PDF에서 메모리 사용량

  ## 후속 개선 후보

  - OCR 페이지 수/DPI/timeout 설정값 외부 설정화
  - OCR 적용 기준 고도화
  - 동일 PDF hash 기반 OCR cache
  - OCR 품질 개선을 위한 page segmentation mode 조정
  - FAST / ACCURATE parsing mode 분리