### PR TITLE
Feature: 단계별 Self-Check 저장/조회 및 단계 이동 검증 추가

### DIFF
--- a/src/main/java/com/example/seedbe/domain/project/repository/ProjectStepRepository.java
+++ b/src/main/java/com/example/seedbe/domain/project/repository/ProjectStepRepository.java
@@ -16,6 +16,8 @@ import jakarta.persistence.LockModeType;
 public interface ProjectStepRepository extends JpaRepository<ProjectStep, UUID> {
     Optional<ProjectStep> findByProjectAndRoadmapStep(Project project, RoadmapStep roadmapStep);
 
+    Optional<ProjectStep> findByProjectAndStepOrder(Project project, Integer stepOrder);
+
     @Query("""
         SELECT ps FROM ProjectStep ps
         JOIN FETCH ps.promptTemplate

--- a/src/main/java/com/example/seedbe/domain/project/service/ProjectService.java
+++ b/src/main/java/com/example/seedbe/domain/project/service/ProjectService.java
@@ -19,6 +19,7 @@ import com.example.seedbe.domain.prompt.entity.PromptTemplate;
 import com.example.seedbe.domain.prompt.repository.PromptTemplateRepository;
 import com.example.seedbe.domain.result.entity.ProjectStepResult;
 import com.example.seedbe.domain.result.repository.ProjectStepResultRepository;
+import com.example.seedbe.domain.selfcheck.repository.ProjectStepSelfCheckRepository;
 import com.example.seedbe.domain.user.entity.User;
 import com.example.seedbe.global.exception.BusinessException;
 import com.example.seedbe.global.exception.ErrorType;
@@ -46,6 +47,7 @@ public class ProjectService {
     private final ProjectStepRepository stepRepository;
     private final PromptTemplateRepository templateRepository;
     private final ProjectStepResultRepository resultRepository;
+    private final ProjectStepSelfCheckRepository selfCheckRepository;
     private final PdfService pdfService;
     private final TransactionTemplate transactionTemplate;
 
@@ -197,6 +199,9 @@ public class ProjectService {
                 .orElseThrow(() -> new BusinessException(ErrorType.GENERATED_RESULT_NOT_FOUND));
         if (result.getContentMarkdown() == null || result.getContentMarkdown().isBlank()) {
             throw new BusinessException(ErrorType.GENERATED_RESULT_NOT_FOUND);
+        }
+        if (!selfCheckRepository.existsByStep(lastStep)) {
+            throw new BusinessException(ErrorType.SELF_CHECK_NOT_FOUND);
         }
 
         project.complete(lastStep);

--- a/src/main/java/com/example/seedbe/domain/prompt/service/ProjectStepPromptService.java
+++ b/src/main/java/com/example/seedbe/domain/prompt/service/ProjectStepPromptService.java
@@ -5,6 +5,7 @@ import com.example.seedbe.domain.project.component.ProjectContext;
 import com.example.seedbe.domain.project.entity.Project;
 import com.example.seedbe.domain.project.entity.ProjectStep;
 import com.example.seedbe.domain.project.enums.RoadmapStep;
+import com.example.seedbe.domain.project.enums.ProjectStepStatus;
 import com.example.seedbe.domain.project.repository.ProjectStepRepository;
 import com.example.seedbe.domain.prompt.component.PromptDiffCalculator;
 import com.example.seedbe.domain.prompt.component.PromptVariableResolver;
@@ -12,6 +13,7 @@ import com.example.seedbe.domain.prompt.component.StepPromptComposer;
 import com.example.seedbe.domain.prompt.dto.ProjectStepPromptResponse;
 import com.example.seedbe.domain.prompt.entity.ProjectStepPrompt;
 import com.example.seedbe.domain.prompt.repository.ProjectStepPromptRepository;
+import com.example.seedbe.domain.selfcheck.repository.ProjectStepSelfCheckRepository;
 import com.example.seedbe.global.exception.BusinessException;
 import com.example.seedbe.global.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class ProjectStepPromptService {
     private final ProjectValidator projectValidator;
     private final ProjectStepRepository stepRepository;
     private final ProjectStepPromptRepository promptRepository;
+    private final ProjectStepSelfCheckRepository selfCheckRepository;
     private final PromptDiffCalculator promptDiffCalculator;
     private final PromptVariableResolver promptVariableResolver;
     private final StepPromptComposer stepPromptComposer;
@@ -41,6 +44,7 @@ public class ProjectStepPromptService {
             step.start();
             return ProjectStepPromptResponse.of(step, existingPrompt.get());
         }
+        validatePreviousStepCompleted(project, step);
 
         String providedPrompt = ProjectContext.isRawDocument(project.getInitialContext())
                 ? stepPromptComposer.compose(step.getRoadmapStep())
@@ -84,6 +88,18 @@ public class ProjectStepPromptService {
         return stepRepository.findByProjectAndRoadmapStepWithPromptTemplateForUpdate(
                         context.project(), context.step())
                 .orElseThrow(() -> new BusinessException(ErrorType.STEP_NOT_STARTED));
+    }
+
+    private void validatePreviousStepCompleted(Project project, ProjectStep step) {
+        if (step.getStepOrder() == 1) {
+            return;
+        }
+        ProjectStep previousStep = stepRepository.findByProjectAndStepOrder(project, step.getStepOrder() - 1)
+                .orElseThrow(() -> new BusinessException(ErrorType.INVALID_ROADMAP_TEMPLATE));
+        if (previousStep.getStatus() != ProjectStepStatus.COMPLETED
+                || !selfCheckRepository.existsByStep(previousStep)) {
+            throw new BusinessException(ErrorType.PREVIOUS_STEP_NOT_COMPLETED);
+        }
     }
 
     private ValidatedContext validateAndGetContext(UUID userId, UUID projectId, String stepCodeStr) {

--- a/src/main/java/com/example/seedbe/domain/selfcheck/controller/ProjectStepSelfCheckController.java
+++ b/src/main/java/com/example/seedbe/domain/selfcheck/controller/ProjectStepSelfCheckController.java
@@ -1,0 +1,51 @@
+package com.example.seedbe.domain.selfcheck.controller;
+
+import com.example.seedbe.domain.selfcheck.dto.ProjectStepSelfCheckResponse;
+import com.example.seedbe.domain.selfcheck.dto.ProjectStepSelfCheckUpdateRequest;
+import com.example.seedbe.domain.selfcheck.service.ProjectStepSelfCheckService;
+import com.example.seedbe.global.common.constants.SwaggerConstants;
+import com.example.seedbe.global.common.response.ApiResponse;
+import com.example.seedbe.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Tag(name = "ProjectStep SelfCheck Controller", description = "프로젝트 단계 이해 확인 API")
+@RestController
+@RequestMapping("/api/projects/{projectId}/steps/{stepCode}/self-check")
+@RequiredArgsConstructor
+public class ProjectStepSelfCheckController {
+    private final ProjectStepSelfCheckService selfCheckService;
+
+    @Operation(summary = "단계 이해 확인 저장 및 수정 (로그인 필요)")
+    @PutMapping
+    public ApiResponse<ProjectStepSelfCheckResponse> saveSelfCheck(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable UUID projectId,
+            @Parameter(description = SwaggerConstants.STEP_CODE_DESCRIPTION) @PathVariable String stepCode,
+            @Valid @RequestBody ProjectStepSelfCheckUpdateRequest request) {
+        return ApiResponse.success(selfCheckService.saveSelfCheck(
+                user.getUser().getUserId(), projectId, stepCode, request.checkItems()));
+    }
+
+    @Operation(summary = "단계 이해 확인 조회 (로그인 필요)")
+    @GetMapping
+    public ApiResponse<ProjectStepSelfCheckResponse> getSelfCheck(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable UUID projectId,
+            @Parameter(description = SwaggerConstants.STEP_CODE_DESCRIPTION) @PathVariable String stepCode) {
+        return ApiResponse.success(selfCheckService.getSelfCheck(
+                user.getUser().getUserId(), projectId, stepCode));
+    }
+}

--- a/src/main/java/com/example/seedbe/domain/selfcheck/dto/ProjectStepSelfCheckResponse.java
+++ b/src/main/java/com/example/seedbe/domain/selfcheck/dto/ProjectStepSelfCheckResponse.java
@@ -1,0 +1,46 @@
+package com.example.seedbe.domain.selfcheck.dto;
+
+import com.example.seedbe.domain.project.entity.ProjectStep;
+import com.example.seedbe.domain.selfcheck.entity.ProjectStepSelfCheck;
+import com.example.seedbe.domain.selfcheck.model.SelfCheckItem;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record ProjectStepSelfCheckResponse(
+        UUID selfCheckId,
+        UUID stepId,
+        String stepCode,
+        String stepName,
+        List<SelfCheckItem> checkItems,
+        LocalDateTime submittedAt,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ProjectStepSelfCheckResponse of(ProjectStep step, ProjectStepSelfCheck selfCheck) {
+        return new ProjectStepSelfCheckResponse(
+                selfCheck.getSelfCheckId(),
+                step.getStepId(),
+                step.getRoadmapStep().getStepCode(),
+                step.getRoadmapStep().getDescription(),
+                selfCheck.getCheckItems(),
+                selfCheck.getSubmittedAt(),
+                selfCheck.getCreatedAt(),
+                selfCheck.getUpdatedAt()
+        );
+    }
+
+    public static ProjectStepSelfCheckResponse unanswered(ProjectStep step, List<SelfCheckItem> checkItems) {
+        return new ProjectStepSelfCheckResponse(
+                null,
+                step.getStepId(),
+                step.getRoadmapStep().getStepCode(),
+                step.getRoadmapStep().getDescription(),
+                checkItems,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/main/java/com/example/seedbe/domain/selfcheck/dto/ProjectStepSelfCheckUpdateRequest.java
+++ b/src/main/java/com/example/seedbe/domain/selfcheck/dto/ProjectStepSelfCheckUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.seedbe.domain.selfcheck.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ProjectStepSelfCheckUpdateRequest(
+        @NotEmpty(message = "이해 확인 문항은 비어있을 수 없습니다.")
+        @Size(min = 3, max = 3, message = "이해 확인 문항 3개에 모두 답변해야 합니다.")
+        List<@Valid SelfCheckItemRequest> checkItems
+) {
+}

--- a/src/main/java/com/example/seedbe/domain/selfcheck/dto/SelfCheckItemRequest.java
+++ b/src/main/java/com/example/seedbe/domain/selfcheck/dto/SelfCheckItemRequest.java
@@ -1,0 +1,15 @@
+package com.example.seedbe.domain.selfcheck.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SelfCheckItemRequest(
+        @NotBlank(message = "문항 key는 비어있을 수 없습니다.")
+        @Size(max = 50, message = "문항 key는 50자를 초과할 수 없습니다.")
+        String key,
+
+        @NotBlank(message = "이해 확인 답변은 비어있을 수 없습니다.")
+        @Size(max = 5_000, message = "이해 확인 답변은 5000자를 초과할 수 없습니다.")
+        String answer
+) {
+}

--- a/src/main/java/com/example/seedbe/domain/selfcheck/entity/ProjectStepSelfCheck.java
+++ b/src/main/java/com/example/seedbe/domain/selfcheck/entity/ProjectStepSelfCheck.java
@@ -1,0 +1,60 @@
+package com.example.seedbe.domain.selfcheck.entity;
+
+import com.example.seedbe.domain.project.entity.ProjectStep;
+import com.example.seedbe.domain.selfcheck.model.SelfCheckItem;
+import com.example.seedbe.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "project_step_self_checks", uniqueConstraints =
+        @UniqueConstraint(name = "uk_project_step_self_checks_step", columnNames = "step_id"))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectStepSelfCheck extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "self_check_id", nullable = false, updatable = false)
+    private UUID selfCheckId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "step_id", nullable = false)
+    private ProjectStep step;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "check_items_json", nullable = false, columnDefinition = "jsonb")
+    private List<SelfCheckItem> checkItems;
+
+    @Column(name = "submitted_at", nullable = false)
+    private LocalDateTime submittedAt;
+
+    @Builder
+    public ProjectStepSelfCheck(ProjectStep step, List<SelfCheckItem> checkItems) {
+        this.step = step;
+        this.checkItems = List.copyOf(checkItems);
+        this.submittedAt = LocalDateTime.now();
+    }
+
+    public void overwrite(List<SelfCheckItem> checkItems) {
+        this.checkItems = List.copyOf(checkItems);
+        this.submittedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/seedbe/domain/selfcheck/enums/SelfCheckQuestionType.java
+++ b/src/main/java/com/example/seedbe/domain/selfcheck/enums/SelfCheckQuestionType.java
@@ -1,0 +1,24 @@
+package com.example.seedbe.domain.selfcheck.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SelfCheckQuestionType {
+    CORE_UNDERSTANDING(
+            "core_understanding",
+            "이번 단계에서 이해한 핵심 내용을 자신의 말로 설명해 주세요."
+    ),
+    RESULT_APPLICATION(
+            "result_application",
+            "이해한 내용을 결과물에 어떻게 적용했으며, 그렇게 적용한 이유는 무엇인가요?"
+    ),
+    UNCERTAINTY_REVIEW(
+            "uncertainty_review",
+            "아직 확실하지 않거나 다시 확인해야 할 부분은 무엇인가요? 없다면 실수하기 쉬운 부분을 작성해 주세요."
+    );
+
+    private final String key;
+    private final String question;
+}

--- a/src/main/java/com/example/seedbe/domain/selfcheck/model/SelfCheckItem.java
+++ b/src/main/java/com/example/seedbe/domain/selfcheck/model/SelfCheckItem.java
@@ -1,0 +1,8 @@
+package com.example.seedbe.domain.selfcheck.model;
+
+public record SelfCheckItem(
+        String key,
+        String question,
+        String answer
+) {
+}

--- a/src/main/java/com/example/seedbe/domain/selfcheck/repository/ProjectStepSelfCheckRepository.java
+++ b/src/main/java/com/example/seedbe/domain/selfcheck/repository/ProjectStepSelfCheckRepository.java
@@ -1,0 +1,14 @@
+package com.example.seedbe.domain.selfcheck.repository;
+
+import com.example.seedbe.domain.project.entity.ProjectStep;
+import com.example.seedbe.domain.selfcheck.entity.ProjectStepSelfCheck;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProjectStepSelfCheckRepository extends JpaRepository<ProjectStepSelfCheck, UUID> {
+    Optional<ProjectStepSelfCheck> findByStep(ProjectStep step);
+
+    boolean existsByStep(ProjectStep step);
+}

--- a/src/main/java/com/example/seedbe/domain/selfcheck/service/ProjectStepSelfCheckService.java
+++ b/src/main/java/com/example/seedbe/domain/selfcheck/service/ProjectStepSelfCheckService.java
@@ -1,0 +1,134 @@
+package com.example.seedbe.domain.selfcheck.service;
+
+import com.example.seedbe.domain.project.component.ProjectValidator;
+import com.example.seedbe.domain.project.entity.Project;
+import com.example.seedbe.domain.project.entity.ProjectStep;
+import com.example.seedbe.domain.project.enums.RoadmapStep;
+import com.example.seedbe.domain.project.repository.ProjectStepRepository;
+import com.example.seedbe.domain.prompt.repository.ProjectStepPromptRepository;
+import com.example.seedbe.domain.result.entity.ProjectStepResult;
+import com.example.seedbe.domain.result.repository.ProjectStepResultRepository;
+import com.example.seedbe.domain.selfcheck.dto.ProjectStepSelfCheckResponse;
+import com.example.seedbe.domain.selfcheck.dto.SelfCheckItemRequest;
+import com.example.seedbe.domain.selfcheck.entity.ProjectStepSelfCheck;
+import com.example.seedbe.domain.selfcheck.enums.SelfCheckQuestionType;
+import com.example.seedbe.domain.selfcheck.model.SelfCheckItem;
+import com.example.seedbe.domain.selfcheck.repository.ProjectStepSelfCheckRepository;
+import com.example.seedbe.global.exception.BusinessException;
+import com.example.seedbe.global.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectStepSelfCheckService {
+    private static final int MIN_ANSWER_CODE_POINT_COUNT = 10;
+
+    private final ProjectValidator projectValidator;
+    private final ProjectStepRepository stepRepository;
+    private final ProjectStepPromptRepository promptRepository;
+    private final ProjectStepResultRepository resultRepository;
+    private final ProjectStepSelfCheckRepository selfCheckRepository;
+
+    @Transactional
+    public ProjectStepSelfCheckResponse saveSelfCheck(UUID userId, UUID projectId, String stepCodeStr,
+                                                      List<SelfCheckItemRequest> requestedItems) {
+        ValidatedContext context = validateAndGetContext(userId, projectId, stepCodeStr);
+        ProjectStep step = stepRepository.findByProjectAndRoadmapStepForUpdate(context.project(), context.step())
+                .orElseThrow(() -> new BusinessException(ErrorType.STEP_NOT_STARTED));
+        if (!promptRepository.existsByStep(step)) {
+            throw new BusinessException(ErrorType.GENERATED_PROMPT_NOT_FOUND);
+        }
+        ProjectStepResult result = resultRepository.findByStep(step)
+                .orElseThrow(() -> new BusinessException(ErrorType.GENERATED_RESULT_NOT_FOUND));
+        if (result.getContentMarkdown() == null || result.getContentMarkdown().isBlank()) {
+            throw new BusinessException(ErrorType.GENERATED_RESULT_NOT_FOUND);
+        }
+
+        List<SelfCheckItem> checkItems = validateAndNormalize(requestedItems);
+        ProjectStepSelfCheck selfCheck = selfCheckRepository.findByStep(step)
+                .map(existing -> {
+                    existing.overwrite(checkItems);
+                    return existing;
+                })
+                .orElseGet(() -> ProjectStepSelfCheck.builder()
+                        .step(step)
+                        .checkItems(checkItems)
+                        .build());
+        selfCheckRepository.saveAndFlush(selfCheck);
+        step.complete();
+        return ProjectStepSelfCheckResponse.of(step, selfCheck);
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectStepSelfCheckResponse getSelfCheck(UUID userId, UUID projectId, String stepCodeStr) {
+        ValidatedContext context = validateAndGetContext(userId, projectId, stepCodeStr);
+        ProjectStep step = stepRepository.findByProjectAndRoadmapStep(context.project(), context.step())
+                .orElseThrow(() -> new BusinessException(ErrorType.STEP_NOT_STARTED));
+        ProjectStepSelfCheck selfCheck = selfCheckRepository.findByStep(step)
+                .orElse(null);
+        return selfCheck == null
+                ? ProjectStepSelfCheckResponse.unanswered(step, getUnansweredItems())
+                : ProjectStepSelfCheckResponse.of(step, selfCheck);
+    }
+
+    private List<SelfCheckItem> validateAndNormalize(List<SelfCheckItemRequest> requestedItems) {
+        SelfCheckQuestionType[] questions = SelfCheckQuestionType.values();
+        if (requestedItems == null || requestedItems.size() != questions.length) {
+            throw new BusinessException(ErrorType.INVALID_SELF_CHECK_ITEMS);
+        }
+
+        Map<String, String> answersByKey = new HashMap<>();
+        for (SelfCheckItemRequest item : requestedItems) {
+            if (item == null || isBlank(item.key()) || isBlank(item.answer())
+                    || answersByKey.putIfAbsent(item.key().strip(), item.answer()) != null) {
+                throw new BusinessException(ErrorType.INVALID_SELF_CHECK_ITEMS);
+            }
+        }
+
+        return Arrays.stream(questions)
+                .map(question -> toSnapshot(question, answersByKey))
+                .toList();
+    }
+
+    private List<SelfCheckItem> getUnansweredItems() {
+        return Arrays.stream(SelfCheckQuestionType.values())
+                .map(question -> new SelfCheckItem(question.getKey(), question.getQuestion(), null))
+                .toList();
+    }
+
+    private SelfCheckItem toSnapshot(SelfCheckQuestionType question, Map<String, String> answersByKey) {
+        String answer = answersByKey.get(question.getKey());
+        if (answer == null) {
+            throw new BusinessException(ErrorType.INVALID_SELF_CHECK_ITEMS);
+        }
+        long answerLength = answer.codePoints()
+                .filter(codePoint -> !Character.isWhitespace(codePoint))
+                .count();
+        if (answerLength < MIN_ANSWER_CODE_POINT_COUNT) {
+            throw new BusinessException(ErrorType.SELF_CHECK_ANSWER_TOO_SHORT);
+        }
+        return new SelfCheckItem(question.getKey(), question.getQuestion(), answer);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private ValidatedContext validateAndGetContext(UUID userId, UUID projectId, String stepCodeStr) {
+        RoadmapStep requestedStep = RoadmapStep.fromStepCode(stepCodeStr);
+        Project project = projectValidator.getProjectWithOwnershipCheck(userId, projectId);
+        project.getRoadmapType().validateStep(requestedStep);
+        return new ValidatedContext(project, requestedStep);
+    }
+
+    private record ValidatedContext(Project project, RoadmapStep step) {
+    }
+}

--- a/src/main/java/com/example/seedbe/global/exception/ErrorType.java
+++ b/src/main/java/com/example/seedbe/global/exception/ErrorType.java
@@ -49,7 +49,13 @@ public enum ErrorType {
     AI_MENTOR_RESPONSE_PARSE_ERROR(HttpStatus.BAD_GATEWAY, "AM004", "AI 멘토 응답을 처리하지 못했습니다."),
     AI_MENTOR_RESPONSE_TRUNCATED(HttpStatus.BAD_GATEWAY, "AM005", "AI 멘토 답변 생성이 완료되지 않았습니다. 다시 시도해 주세요."),
     AI_MENTOR_DAILY_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "AM006", "오늘 사용할 수 있는 AI 멘토 질문 40회를 모두 사용했습니다."),
-    AI_MENTOR_RESPONSE_FORMAT_ERROR(HttpStatus.BAD_GATEWAY, "AM007", "AI 멘토가 답변 형식을 지키지 못했습니다. 다시 시도해 주세요.");
+    AI_MENTOR_RESPONSE_FORMAT_ERROR(HttpStatus.BAD_GATEWAY, "AM007", "AI 멘토가 답변 형식을 지키지 못했습니다. 다시 시도해 주세요."),
+
+    // [Self Check] 단계별 이해 확인 관련
+    SELF_CHECK_NOT_FOUND(HttpStatus.BAD_REQUEST, "SC001", "해당 단계의 이해 확인 답변을 등록해야 합니다."),
+    SELF_CHECK_ANSWER_TOO_SHORT(HttpStatus.BAD_REQUEST, "SC002", "각 이해 확인 답변은 공백을 제외하고 10자 이상이어야 합니다."),
+    PREVIOUS_STEP_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "SC003", "이전 단계의 결과물과 이해 확인을 먼저 완료해야 합니다."),
+    INVALID_SELF_CHECK_ITEMS(HttpStatus.BAD_REQUEST, "SC004", "정해진 이해 확인 문항에 모두 답변해야 합니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/example/seedbe/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/example/seedbe/domain/project/service/ProjectServiceTest.java
@@ -18,6 +18,7 @@ import com.example.seedbe.domain.prompt.entity.PromptTemplate;
 import com.example.seedbe.domain.prompt.repository.PromptTemplateRepository;
 import com.example.seedbe.domain.result.repository.ProjectStepResultRepository;
 import com.example.seedbe.domain.result.entity.ProjectStepResult;
+import com.example.seedbe.domain.selfcheck.repository.ProjectStepSelfCheckRepository;
 import com.example.seedbe.domain.user.entity.User;
 import com.example.seedbe.domain.user.enums.Role;
 import com.example.seedbe.global.exception.BusinessException;
@@ -56,6 +57,7 @@ class ProjectServiceTest {
     @Mock private ProjectStepRepository stepRepository;
     @Mock private PromptTemplateRepository templateRepository;
     @Mock private ProjectStepResultRepository resultRepository;
+    @Mock private ProjectStepSelfCheckRepository selfCheckRepository;
     @Mock private PdfService pdfService;
     @Mock private TransactionTemplate transactionTemplate;
     @Mock private TransactionStatus transactionStatus;
@@ -236,7 +238,7 @@ class ProjectServiceTest {
     }
 
     @Test
-    @DisplayName("마지막 단계 결과물이 있으면 프로젝트를 완료한다.")
+    @DisplayName("마지막 단계 결과물과 이해 확인이 있으면 프로젝트를 완료한다.")
     void completeProjectWithSavedLastResult() {
         UUID userId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
@@ -249,6 +251,7 @@ class ProjectServiceTest {
         when(stepRepository.findByProjectAndRoadmapStep(project, RoadmapStep.REPORT_REVISION))
                 .thenReturn(Optional.of(lastStep));
         when(resultRepository.findByStep(lastStep)).thenReturn(Optional.of(result));
+        when(selfCheckRepository.existsByStep(lastStep)).thenReturn(true);
 
         service().completeProject(userId, projectId);
 
@@ -256,9 +259,30 @@ class ProjectServiceTest {
         assertThat(project.getCompletedAt()).isNotNull();
     }
 
+    @Test
+    @DisplayName("마지막 단계 이해 확인이 없으면 프로젝트를 완료할 수 없다.")
+    void completeProjectRejectsMissingSelfCheck() {
+        UUID userId = UUID.randomUUID();
+        UUID projectId = UUID.randomUUID();
+        Project project = createProject();
+        ProjectStep lastStep = ProjectStep.builder().project(project).promptTemplate(mock(PromptTemplate.class))
+                .roadmapStep(RoadmapStep.REPORT_REVISION).stepOrder(4).build();
+        ProjectStepResult result = ProjectStepResult.builder()
+                .step(lastStep).contentMarkdown("# 최종 결과").build();
+        when(projectValidator.getProjectWithOwnershipCheck(userId, projectId)).thenReturn(project);
+        when(stepRepository.findByProjectAndRoadmapStep(project, RoadmapStep.REPORT_REVISION))
+                .thenReturn(Optional.of(lastStep));
+        when(resultRepository.findByStep(lastStep)).thenReturn(Optional.of(result));
+        when(selfCheckRepository.existsByStep(lastStep)).thenReturn(false);
+
+        assertThatThrownBy(() -> service().completeProject(userId, projectId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorType").isEqualTo(ErrorType.SELF_CHECK_NOT_FOUND);
+    }
+
     private ProjectService service() {
         return new ProjectService(projectValidator, projectRepository, stepRepository, templateRepository,
-                resultRepository, pdfService, transactionTemplate);
+                resultRepository, selfCheckRepository, pdfService, transactionTemplate);
     }
 
     private Project createProject() {

--- a/src/test/java/com/example/seedbe/domain/prompt/service/ProjectStepPromptServiceTest.java
+++ b/src/test/java/com/example/seedbe/domain/prompt/service/ProjectStepPromptServiceTest.java
@@ -16,6 +16,7 @@ import com.example.seedbe.domain.project.enums.RoadmapType;
 import com.example.seedbe.domain.prompt.repository.ProjectStepPromptRepository;
 import com.example.seedbe.domain.project.repository.ProjectStepRepository;
 import com.example.seedbe.domain.prompt.entity.PromptTemplate;
+import com.example.seedbe.domain.selfcheck.repository.ProjectStepSelfCheckRepository;
 import com.example.seedbe.global.exception.BusinessException;
 import com.example.seedbe.global.exception.ErrorType;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ class ProjectStepPromptServiceTest {
     @Mock private ProjectValidator projectValidator;
     @Mock private ProjectStepRepository stepRepository;
     @Mock private ProjectStepPromptRepository promptRepository;
+    @Mock private ProjectStepSelfCheckRepository selfCheckRepository;
     @Mock private PromptTemplate promptTemplate;
 
     private final UUID userId = UUID.randomUUID();
@@ -146,9 +148,66 @@ class ProjectStepPromptServiceTest {
                 .extracting("errorType").isEqualTo(ErrorType.GENERATED_PROMPT_NOT_FOUND);
     }
 
+    @Test
+    void rejectsStartingNextStepBeforePreviousStepCompletion() {
+        Project project = createProject();
+        ProjectStep previousStep = createStep(project);
+        ProjectStep nextStep = ProjectStep.builder().project(project).promptTemplate(promptTemplate)
+                .roadmapStep(RoadmapStep.ARGUMENT_STRUCTURING).stepOrder(2).build();
+        when(projectValidator.getProjectWithOwnershipCheck(userId, projectId)).thenReturn(project);
+        when(stepRepository.findByProjectAndRoadmapStepWithPromptTemplateForUpdate(
+                project, RoadmapStep.ARGUMENT_STRUCTURING)).thenReturn(Optional.of(nextStep));
+        when(stepRepository.findByProjectAndStepOrder(project, 1)).thenReturn(Optional.of(previousStep));
+
+        assertThatThrownBy(() -> service().createPrompt(userId, projectId, "argument_structuring"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorType").isEqualTo(ErrorType.PREVIOUS_STEP_NOT_COMPLETED);
+        verify(promptRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void rejectsStartingNextStepWhenPreviousSelfCheckIsMissing() {
+        Project project = createProject();
+        ProjectStep previousStep = createStep(project);
+        previousStep.complete();
+        ProjectStep nextStep = ProjectStep.builder().project(project).promptTemplate(promptTemplate)
+                .roadmapStep(RoadmapStep.ARGUMENT_STRUCTURING).stepOrder(2).build();
+        when(projectValidator.getProjectWithOwnershipCheck(userId, projectId)).thenReturn(project);
+        when(stepRepository.findByProjectAndRoadmapStepWithPromptTemplateForUpdate(
+                project, RoadmapStep.ARGUMENT_STRUCTURING)).thenReturn(Optional.of(nextStep));
+        when(stepRepository.findByProjectAndStepOrder(project, 1)).thenReturn(Optional.of(previousStep));
+        when(selfCheckRepository.existsByStep(previousStep)).thenReturn(false);
+
+        assertThatThrownBy(() -> service().createPrompt(userId, projectId, "argument_structuring"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorType").isEqualTo(ErrorType.PREVIOUS_STEP_NOT_COMPLETED);
+    }
+
+    @Test
+    void returnsLegacyExistingPromptWithoutPreviousSelfCheck() {
+        Project project = createProject();
+        ProjectStep nextStep = ProjectStep.builder().project(project).promptTemplate(promptTemplate)
+                .roadmapStep(RoadmapStep.ARGUMENT_STRUCTURING).stepOrder(2).build();
+        ProjectStepPrompt existingPrompt = createPrompt(nextStep, "legacy provided");
+        when(projectValidator.getProjectWithOwnershipCheck(userId, projectId)).thenReturn(project);
+        when(stepRepository.findByProjectAndRoadmapStepWithPromptTemplateForUpdate(
+                project, RoadmapStep.ARGUMENT_STRUCTURING)).thenReturn(Optional.of(nextStep));
+        when(promptRepository.findByStep(nextStep)).thenReturn(Optional.of(existingPrompt));
+        when(promptTemplate.getFormatPrompt()).thenReturn("format");
+
+        ProjectStepPromptResponse response = service().createPrompt(
+                userId, projectId, "argument_structuring");
+
+        assertThat(response.providedPromptSnapshot()).isEqualTo("legacy provided");
+        assertThat(nextStep.getStatus()).isEqualTo(ProjectStepStatus.IN_PROGRESS);
+        verify(stepRepository, never()).findByProjectAndStepOrder(any(), any());
+        verify(selfCheckRepository, never()).existsByStep(any());
+    }
+
     private ProjectStepPromptService service() {
         return new ProjectStepPromptService(projectValidator, stepRepository, promptRepository,
-                new PromptDiffCalculator(), new PromptVariableResolver(), new StepPromptComposer());
+                selfCheckRepository, new PromptDiffCalculator(), new PromptVariableResolver(),
+                new StepPromptComposer());
     }
 
     private Project createProject() {

--- a/src/test/java/com/example/seedbe/domain/selfcheck/controller/ProjectStepSelfCheckControllerTest.java
+++ b/src/test/java/com/example/seedbe/domain/selfcheck/controller/ProjectStepSelfCheckControllerTest.java
@@ -1,0 +1,116 @@
+package com.example.seedbe.domain.selfcheck.controller;
+
+import com.example.seedbe.domain.selfcheck.dto.ProjectStepSelfCheckResponse;
+import com.example.seedbe.domain.selfcheck.dto.SelfCheckItemRequest;
+import com.example.seedbe.domain.selfcheck.model.SelfCheckItem;
+import com.example.seedbe.domain.selfcheck.service.ProjectStepSelfCheckService;
+import com.example.seedbe.domain.user.entity.User;
+import com.example.seedbe.global.security.CustomUserDetails;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ProjectStepSelfCheckControllerTest {
+    private final ProjectStepSelfCheckService selfCheckService = mock(ProjectStepSelfCheckService.class);
+    private final UUID userId = UUID.randomUUID();
+    private final UUID projectId = UUID.randomUUID();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        User user = mock(User.class);
+        when(user.getUserId()).thenReturn(userId);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        mockMvc = MockMvcBuilders.standaloneSetup(new ProjectStepSelfCheckController(selfCheckService))
+                .setCustomArgumentResolvers(authenticationPrincipalResolver(userDetails))
+                .build();
+    }
+
+    @Test
+    void savesAndGetsSelfCheckItems() throws Exception {
+        String answer = "핵심 제약사항을 구체적으로 이해했습니다.";
+        List<SelfCheckItemRequest> requests = List.of(
+                new SelfCheckItemRequest("core_understanding", answer),
+                new SelfCheckItemRequest("result_application", answer),
+                new SelfCheckItemRequest("uncertainty_review", answer));
+        ProjectStepSelfCheckResponse response = new ProjectStepSelfCheckResponse(
+                UUID.randomUUID(), UUID.randomUUID(), "constraint_analysis", "제약사항 분석",
+                List.of(new SelfCheckItem("core_understanding",
+                        "이번 단계에서 이해한 핵심 내용을 자신의 말로 설명해 주세요.", answer)),
+                LocalDateTime.now(), null, null);
+        when(selfCheckService.saveSelfCheck(userId, projectId, "constraint_analysis", requests))
+                .thenReturn(response);
+        when(selfCheckService.getSelfCheck(userId, projectId, "constraint_analysis")).thenReturn(response);
+        String path = "/api/projects/" + projectId + "/steps/constraint_analysis/self-check";
+
+        mockMvc.perform(put(path)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"checkItems":[
+                                  {"key":"core_understanding","answer":"핵심 제약사항을 구체적으로 이해했습니다."},
+                                  {"key":"result_application","answer":"핵심 제약사항을 구체적으로 이해했습니다."},
+                                  {"key":"uncertainty_review","answer":"핵심 제약사항을 구체적으로 이해했습니다."}
+                                ]}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.checkItems[0].key").value("core_understanding"))
+                .andExpect(jsonPath("$.data.checkItems[0].answer").value(answer));
+        mockMvc.perform(get(path))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.stepCode").value("constraint_analysis"));
+
+        verify(selfCheckService).saveSelfCheck(userId, projectId, "constraint_analysis", requests);
+        verify(selfCheckService).getSelfCheck(userId, projectId, "constraint_analysis");
+    }
+
+    @Test
+    void rejectsBlankAnswer() throws Exception {
+        String path = "/api/projects/" + projectId + "/steps/constraint_analysis/self-check";
+
+        mockMvc.perform(put(path)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"checkItems":[
+                                  {"key":"core_understanding","answer":"   "},
+                                  {"key":"result_application","answer":"충분한 길이의 두 번째 답변입니다."},
+                                  {"key":"uncertainty_review","answer":"충분한 길이의 세 번째 답변입니다."}
+                                ]}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    private HandlerMethodArgumentResolver authenticationPrincipalResolver(CustomUserDetails userDetails) {
+        return new HandlerMethodArgumentResolver() {
+            @Override
+            public boolean supportsParameter(MethodParameter parameter) {
+                return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+            }
+
+            @Override
+            public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                          NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+                return userDetails;
+            }
+        };
+    }
+}

--- a/src/test/java/com/example/seedbe/domain/selfcheck/entity/ProjectStepSelfCheckMappingTest.java
+++ b/src/test/java/com/example/seedbe/domain/selfcheck/entity/ProjectStepSelfCheckMappingTest.java
@@ -1,0 +1,27 @@
+package com.example.seedbe.domain.selfcheck.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProjectStepSelfCheckMappingTest {
+    @Test
+    void mapsUniqueStepAndJsonbItems() throws NoSuchFieldException {
+        Table table = ProjectStepSelfCheck.class.getAnnotation(Table.class);
+        Column column = ProjectStepSelfCheck.class.getDeclaredField("checkItems").getAnnotation(Column.class);
+
+        assertThat(Arrays.stream(table.uniqueConstraints())
+                .map(UniqueConstraint::columnNames)
+                .anyMatch(columns -> Arrays.equals(columns, new String[]{"step_id"})))
+                .isTrue();
+        assertThat(column.columnDefinition()).isEqualTo("jsonb");
+        assertThat(ProjectStepSelfCheck.class.getDeclaredField("checkItems")
+                .isAnnotationPresent(JdbcTypeCode.class)).isTrue();
+    }
+}

--- a/src/test/java/com/example/seedbe/domain/selfcheck/service/ProjectStepSelfCheckServiceTest.java
+++ b/src/test/java/com/example/seedbe/domain/selfcheck/service/ProjectStepSelfCheckServiceTest.java
@@ -1,0 +1,219 @@
+package com.example.seedbe.domain.selfcheck.service;
+
+import com.example.seedbe.domain.project.component.ProjectValidator;
+import com.example.seedbe.domain.project.entity.Project;
+import com.example.seedbe.domain.project.entity.ProjectStep;
+import com.example.seedbe.domain.project.enums.ProjectStatus;
+import com.example.seedbe.domain.project.enums.ProjectStepStatus;
+import com.example.seedbe.domain.project.enums.RoadmapStep;
+import com.example.seedbe.domain.project.enums.RoadmapType;
+import com.example.seedbe.domain.project.repository.ProjectStepRepository;
+import com.example.seedbe.domain.prompt.entity.PromptTemplate;
+import com.example.seedbe.domain.prompt.repository.ProjectStepPromptRepository;
+import com.example.seedbe.domain.result.entity.ProjectStepResult;
+import com.example.seedbe.domain.result.repository.ProjectStepResultRepository;
+import com.example.seedbe.domain.selfcheck.dto.ProjectStepSelfCheckResponse;
+import com.example.seedbe.domain.selfcheck.dto.SelfCheckItemRequest;
+import com.example.seedbe.domain.selfcheck.entity.ProjectStepSelfCheck;
+import com.example.seedbe.domain.selfcheck.repository.ProjectStepSelfCheckRepository;
+import com.example.seedbe.global.exception.BusinessException;
+import com.example.seedbe.global.exception.ErrorType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectStepSelfCheckServiceTest {
+    @Mock private ProjectValidator projectValidator;
+    @Mock private ProjectStepRepository stepRepository;
+    @Mock private ProjectStepPromptRepository promptRepository;
+    @Mock private ProjectStepResultRepository resultRepository;
+    @Mock private ProjectStepSelfCheckRepository selfCheckRepository;
+
+    private final UUID userId = UUID.randomUUID();
+    private final UUID projectId = UUID.randomUUID();
+
+    @Test
+    void createsSelfCheckAndCompletesStep() {
+        Project project = createProject();
+        ProjectStep step = createStep(project);
+        stubSaveContext(project, step);
+        when(promptRepository.existsByStep(step)).thenReturn(true);
+        when(resultRepository.findByStep(step)).thenReturn(Optional.of(savedResult(step)));
+        when(selfCheckRepository.findByStep(step)).thenReturn(Optional.empty());
+        when(selfCheckRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ProjectStepSelfCheckResponse response = service().saveSelfCheck(
+                userId, projectId, "constraint_analysis", validItems("처음 작성한 충분한 길이의 답변입니다."));
+
+        assertThat(response.checkItems()).hasSize(3)
+                .allSatisfy(item -> assertThat(item.answer()).contains("충분한 길이"));
+        assertThat(step.getStatus()).isEqualTo(ProjectStepStatus.COMPLETED);
+        assertThat(step.getCompletedAt()).isNotNull();
+        verify(selfCheckRepository).saveAndFlush(any(ProjectStepSelfCheck.class));
+    }
+
+    @Test
+    void overwritesExistingSelfCheck() {
+        Project project = createProject();
+        ProjectStep step = createStep(project);
+        ProjectStepSelfCheck existing = ProjectStepSelfCheck.builder()
+                .step(step)
+                .checkItems(List.of(new com.example.seedbe.domain.selfcheck.model.SelfCheckItem(
+                        "understanding", "질문", "기존 답변은 충분히 길게 작성됨")))
+                .build();
+        stubSaveContext(project, step);
+        when(promptRepository.existsByStep(step)).thenReturn(true);
+        when(resultRepository.findByStep(step)).thenReturn(Optional.of(savedResult(step)));
+        when(selfCheckRepository.findByStep(step)).thenReturn(Optional.of(existing));
+        when(selfCheckRepository.saveAndFlush(existing)).thenReturn(existing);
+
+        service().saveSelfCheck(userId, projectId, "constraint_analysis",
+                validItems("수정한 답변도 충분한 길이로 작성했습니다."));
+
+        assertThat(existing.getCheckItems().getFirst().answer()).startsWith("수정한 답변");
+    }
+
+    @Test
+    void getsSavedSelfCheck() {
+        Project project = createProject();
+        ProjectStep step = createStep(project);
+        ProjectStepSelfCheck saved = ProjectStepSelfCheck.builder()
+                .step(step)
+                .checkItems(List.of(new com.example.seedbe.domain.selfcheck.model.SelfCheckItem(
+                        "understanding", "무엇을 이해했나요?", "핵심 내용을 충분하게 이해했습니다.")))
+                .build();
+        stubReadContext(project, step);
+        when(selfCheckRepository.findByStep(step)).thenReturn(Optional.of(saved));
+
+        assertThat(service().getSelfCheck(userId, projectId, "constraint_analysis").checkItems())
+                .hasSize(1);
+    }
+
+    @Test
+    void returnsPredefinedQuestionsBeforeSubmission() {
+        Project project = createProject();
+        ProjectStep step = createStep(project);
+        stubReadContext(project, step);
+        when(selfCheckRepository.findByStep(step)).thenReturn(Optional.empty());
+
+        ProjectStepSelfCheckResponse response = service().getSelfCheck(
+                userId, projectId, "constraint_analysis");
+
+        assertThat(response.selfCheckId()).isNull();
+        assertThat(response.checkItems()).extracting("key")
+                .containsExactly("core_understanding", "result_application", "uncertainty_review");
+        assertThat(response.checkItems()).extracting("answer").containsOnlyNulls();
+    }
+
+    @Test
+    void rejectsAnswerShorterThanTenCodePoints() {
+        Project project = createProject();
+        ProjectStep step = createStep(project);
+        stubSaveContext(project, step);
+        when(promptRepository.existsByStep(step)).thenReturn(true);
+        when(resultRepository.findByStep(step)).thenReturn(Optional.of(savedResult(step)));
+
+        assertThatThrownBy(() -> service().saveSelfCheck(
+                userId, projectId, "constraint_analysis", validItems("짧은 답변")))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorType").isEqualTo(ErrorType.SELF_CHECK_ANSWER_TOO_SHORT);
+        verify(selfCheckRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void rejectsSelfCheckBeforeResultIsSaved() {
+        Project project = createProject();
+        ProjectStep step = createStep(project);
+        stubSaveContext(project, step);
+        when(promptRepository.existsByStep(step)).thenReturn(true);
+        when(resultRepository.findByStep(step)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service().saveSelfCheck(
+                userId, projectId, "constraint_analysis", validItems("충분한 길이로 작성한 답변입니다.")))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorType").isEqualTo(ErrorType.GENERATED_RESULT_NOT_FOUND);
+    }
+
+    @Test
+    void rejectsUnknownQuestionKey() {
+        Project project = createProject();
+        ProjectStep step = createStep(project);
+        stubSaveContext(project, step);
+        when(promptRepository.existsByStep(step)).thenReturn(true);
+        when(resultRepository.findByStep(step)).thenReturn(Optional.of(savedResult(step)));
+        List<SelfCheckItemRequest> items = List.of(
+                new SelfCheckItemRequest("unknown", "충분한 길이로 작성한 첫 번째 답변입니다."),
+                new SelfCheckItemRequest("result_application", "충분한 길이로 작성한 두 번째 답변입니다."),
+                new SelfCheckItemRequest("uncertainty_review", "충분한 길이로 작성한 세 번째 답변입니다.")
+        );
+
+        assertThatThrownBy(() -> service().saveSelfCheck(
+                userId, projectId, "constraint_analysis", items))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorType").isEqualTo(ErrorType.INVALID_SELF_CHECK_ITEMS);
+    }
+
+    @Test
+    void rejectsAccessToAnotherUsersProject() {
+        when(projectValidator.getProjectWithOwnershipCheck(userId, projectId))
+                .thenThrow(new BusinessException(ErrorType.FORBIDDEN_ACCESS));
+
+        assertThatThrownBy(() -> service().getSelfCheck(userId, projectId, "constraint_analysis"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorType").isEqualTo(ErrorType.FORBIDDEN_ACCESS);
+        verify(stepRepository, never()).findByProjectAndRoadmapStep(any(), any());
+    }
+
+    private ProjectStepSelfCheckService service() {
+        return new ProjectStepSelfCheckService(projectValidator, stepRepository, promptRepository,
+                resultRepository, selfCheckRepository);
+    }
+
+    private List<SelfCheckItemRequest> validItems(String answer) {
+        return List.of(
+                new SelfCheckItemRequest("core_understanding", answer),
+                new SelfCheckItemRequest("result_application", answer),
+                new SelfCheckItemRequest("uncertainty_review", answer)
+        );
+    }
+
+    private Project createProject() {
+        return Project.builder().title("title").roadmapType(RoadmapType.REPORT)
+                .status(ProjectStatus.IN_PROGRESS).initialContext(Map.of()).build();
+    }
+
+    private ProjectStep createStep(Project project) {
+        return ProjectStep.builder().project(project).promptTemplate(org.mockito.Mockito.mock(PromptTemplate.class))
+                .roadmapStep(RoadmapStep.CONSTRAINT_ANALYSIS).stepOrder(1).build();
+    }
+
+    private ProjectStepResult savedResult(ProjectStep step) {
+        return ProjectStepResult.builder().step(step).contentMarkdown("# 저장된 결과물").build();
+    }
+
+    private void stubSaveContext(Project project, ProjectStep step) {
+        when(projectValidator.getProjectWithOwnershipCheck(userId, projectId)).thenReturn(project);
+        when(stepRepository.findByProjectAndRoadmapStepForUpdate(project, RoadmapStep.CONSTRAINT_ANALYSIS))
+                .thenReturn(Optional.of(step));
+    }
+
+    private void stubReadContext(Project project, ProjectStep step) {
+        when(projectValidator.getProjectWithOwnershipCheck(userId, projectId)).thenReturn(project);
+        when(stepRepository.findByProjectAndRoadmapStep(project, RoadmapStep.CONSTRAINT_ANALYSIS))
+                .thenReturn(Optional.of(step));
+    }
+}


### PR DESCRIPTION
  ## 개요

  로드맵 단계 완료 전 학습자가 자신의 이해도를 직접 확인할 수 있도록
  단계별 Self-Check 저장 및 조회 기능을 추가했습니다.

  Self-Check는 모든 단계에서 공통으로 사용하는 질문 3개로 구성되며,
  질문에 모두 답변하고 단계 결과물까지 저장해야 현재 단계가 완료됩니다.

  또한 Self-Check를 제출하지 않은 상태에서 다음 단계로 이동하거나
  프로젝트를 완료할 수 없도록 서버 검증을 추가했습니다.

  ---

  ## 관련 API

  ### Self-Check 저장 및 수정

  ```http
  PUT /api/projects/{projectId}/steps/{stepCode}/self-check
```
  ### Self-Check 조회

  GET /api/projects/{projectId}/steps/{stepCode}/self-check

  기존 프로젝트 단계 프롬프트 API와 프로젝트 완료 API에도
  Self-Check 기반 진행 제한 정책이 적용됩니다.

  POST /api/projects/{projectId}/steps/{stepCode}/prompt
  PATCH /api/projects/{projectId}/complete

  ———

  ## 1. Self-Check 도메인 추가

  기존 project 패키지에 기능을 추가하지 않고
  domain/selfcheck 패키지로 분리했습니다.

  추가된 구성은 다음과 같습니다.

  - ProjectStepSelfCheckController
  - ProjectStepSelfCheckService
  - ProjectStepSelfCheckRepository
  - ProjectStepSelfCheck
  - SelfCheckQuestionType
  - SelfCheckItem
  - Self-Check 요청 및 응답 DTO

  Controller, Service, Repository, Entity, DTO의 책임을 분리했으며,
  Entity를 API 응답으로 직접 반환하지 않습니다.

  ———

  ## 2. ProjectStepSelfCheck Entity

  ERD의 project_step_self_checks 테이블을 기준으로 매핑했습니다.

  주요 컬럼:

  - self_check_id
  - step_id
  - check_items_json
  - submitted_at
  - created_at
  - updated_at

  step_id에는 unique constraint가 있으므로
  단계당 Self-Check 레코드는 하나만 존재합니다.

  ProjectStep 1:1 ProjectStepSelfCheck

  연관관계는 ProjectStepSelfCheck에서만 관리하는 단방향 구조입니다.

  @OneToOne(fetch = FetchType.LAZY)
  @JoinColumn(name = "step_id", nullable = false)
  private ProjectStep step;

  ProjectStep에 역방향 연관관계를 추가하지 않아
  단계 요약 조회 시 불필요한 Self-Check 조회가 발생하지 않도록 했습니다.

  ———

  ## 3. check_items_json 저장 구조

  check_items_json은 PostgreSQL JSONB 타입으로 매핑했습니다.

  @JdbcTypeCode(SqlTypes.JSON)
  @Column(name = "check_items_json", nullable = false, columnDefinition = "jsonb")
  private List<SelfCheckItem> checkItems;

  DB에는 다음 구조로 저장됩니다.

  ```http
  [
    {
      "key": "core_understanding",
      "question": "이번 단계에서 이해한 핵심 내용을 자신의 말로 설명해 주세요.",
      "answer": "이번 단계에서는 제약사항의 우선순위를 판단하는 기준을 이해했습니다."
    },
    {
      "key": "result_application",
      "question": "이해한 내용을 결과물에 어떻게 적용했으며, 그렇게 적용한 이유는 무엇인가요?",
      "answer": "중요한 제약사항을 먼저 배치해 결과물의 논리 구조를 명확하게 만들었습니다."
    },
    {
      "key": "uncertainty_review",
      "question": "아직 확실하지 않거나 다시 확인해야 할 부분은 무엇인가요? 없다면 실수하기 쉬운 부분
      을 작성해 주세요.",
      "answer": "제약사항의 우선순위가 바뀌는 조건을 다시 확인해야 합니다."
    }
  ]
```

  질문 문구를 snapshot으로 함께 저장하므로,
  향후 enum의 질문 문구가 변경되더라도 과거 학습자가
  어떤 질문에 답변했는지 확인할 수 있습니다.

  ———

  ## 4. 고정 Self-Check 질문 관리

  질문 목록을 별도 DB 테이블로 관리하지 않고
  SelfCheckQuestionType enum으로 관리합니다.

  현재 모든 단계에서 다음 3개 질문을 공통으로 사용합니다.

  ### CORE_UNDERSTANDING

  이번 단계에서 이해한 핵심 내용을 자신의 말로 설명해 주세요.

  ### RESULT_APPLICATION

  이해한 내용을 결과물에 어떻게 적용했으며,
  그렇게 적용한 이유는 무엇인가요?

  ### UNCERTAINTY_REVIEW

  아직 확실하지 않거나 다시 확인해야 할 부분은 무엇인가요?
  없다면 실수하기 쉬운 부분을 작성해 주세요.

  각 enum은 다음 정보를 가집니다.

  private final String key;
  private final String question;

  enum 선언 순서를 질문 표시 및 DB 저장 순서로 사용합니다.

  따라서 프론트가 다른 순서로 답변을 보내더라도
  DB에는 서버에서 정의한 순서로 정규화되어 저장됩니다.

  ———

  ## 5. Self-Check 조회 정책

  Self-Check 조회 API는 제출 여부에 따라 다르게 응답합니다.

  ### 아직 제출하지 않은 경우

  미리 정의된 질문 3개와 answer: null을 반환합니다.

  ```http
  {
    "data": {
      "selfCheckId": null,
      "stepId": "step-uuid",
      "stepCode": "constraint_analysis",
      "stepName": "제약사항 분석",
      "checkItems": [
        {
          "key": "core_understanding",
          "question": "이번 단계에서 이해한 핵심 내용을 자신의 말로 설명해 주세요.",
          "answer": null
        },
        {
          "key": "result_application",
          "question": "이해한 내용을 결과물에 어떻게 적용했으며, 그렇게 적용한 이유는 무엇인가요?",
          "answer": null
        },
        {
          "key": "uncertainty_review",
          "question": "아직 확실하지 않거나 다시 확인해야 할 부분은 무엇인가요? 없다면 실수하기 쉬운
          부분을 작성해 주세요.",
          "answer": null
        }
      ],
      "submittedAt": null,
      "createdAt": null,
      "updatedAt": null
    }
  }
```

  프론트는 다음 단계 이동 모달을 열 때 이 API를 호출하여
  질문 목록을 표시할 수 있습니다.

  ### 이미 제출한 경우

  DB에 저장된 질문 snapshot과 사용자 답변을 반환합니다.

  마이페이지 또는 프로젝트 단계 상세 조회에서도
  동일한 응답을 재사용할 수 있습니다.

  ———

  ## 6. Self-Check 저장 요청 단순화

  프론트는 질문 문구를 전송하지 않고
  질문 key와 사용자 답변만 전송합니다.

  ```http
  {
    "checkItems": [
      {
        "key": "core_understanding",
        "answer": "이번 단계에서 이해한 핵심 내용을 작성합니다."
      },
      {
        "key": "result_application",
        "answer": "결과물에 적용한 방법과 그 이유를 작성합니다."
      },
      {
        "key": "uncertainty_review",
        "answer": "다시 확인해야 하는 부분이나 실수하기 쉬운 부분을 작성합니다."
      }
    ]
  }
```

  서버는 key를 SelfCheckQuestionType과 비교하여 검증한 뒤,
  enum의 질문 문구를 결합해 DB snapshot을 생성합니다.

  이를 통해 클라이언트가 질문 문구를 임의로 수정하거나
  다른 질문에 대한 답변을 저장하는 것을 방지합니다.

  ———

  ## 7. Self-Check 입력 검증

  다음 입력은 저장할 수 없습니다.

  - 문항 목록이 null 또는 빈 배열
  - 질문 3개 중 일부만 제출
  - 정의되지 않은 질문 key 제출
  - 동일한 질문 key 중복 제출
  - key 또는 answer가 null
  - 공백으로만 구성된 답변
  - 최소 길이보다 짧은 답변

  각 답변은 whitespace를 제외한 Unicode code point 기준으로
  최소 10자 이상이어야 합니다.

  long answerLength = answer.codePoints()
          .filter(codePoint -> !Character.isWhitespace(codePoint))
          .count();

  Java의 단순 String.length() 대신 code point 기준으로 계산하여
  surrogate pair가 포함된 문자도 하나의 문자로 처리합니다.

  API DTO에서는 다음 크기 제한도 적용합니다.

  - 문항: 정확히 3개
  - key: 최대 50자
  - 답변: 최대 5,000자

  ———

  ## 8. 저장 및 Overwrite 정책

  단계당 Self-Check 레코드는 하나만 유지합니다.

  ### 최초 제출

  새로운 ProjectStepSelfCheck Entity를 생성합니다.

  ### 기존 답변 수정

  기존 Entity의 checkItems를 overwrite하고
  submittedAt을 현재 시각으로 갱신합니다.

  public void overwrite(List<SelfCheckItem> checkItems) {
      this.checkItems = List.copyOf(checkItems);
      this.submittedAt = LocalDateTime.now();
  }

  별도의 revision 또는 전체 수정 이력 기능은 이번 범위에 포함하지 않습니다.

  ———

  ## 9. Self-Check 제출 전 선행 조건 검증

  Self-Check를 저장하려면 다음 데이터가 모두 존재해야 합니다.

  1. 해당 단계의 프롬프트
  2. 비어 있지 않은 단계 결과물
  3. 유효한 Self-Check 답변 3개

  프롬프트가 없으면 다음 예외를 반환합니다.

  AP004 GENERATED_PROMPT_NOT_FOUND

  결과물이 없거나 본문이 비어 있으면 다음 예외를 반환합니다.

  AP003 GENERATED_RESULT_NOT_FOUND

  따라서 단계 진행 순서는 다음과 같이 강제됩니다.

  프롬프트 생성
  → 결과물 작성
  → Self-Check 제출
  → 단계 완료

  ———

  ## 10. Transaction과 동시성 처리

  Self-Check 저장 메서드는 하나의 transaction으로 처리합니다.

  @Transactional
  public ProjectStepSelfCheckResponse saveSelfCheck(...)

  transaction 내부에서 다음 작업을 수행합니다.

  1. 프로젝트 ownership 검증
  2. ProjectStep row lock
  3. 프롬프트 및 결과물 검증
  4. Self-Check 저장 또는 수정
  5. ProjectStep 완료 처리

  단계 조회에는 PESSIMISTIC_WRITE lock이 적용된 기존 Repository 메서드를 사용합니다.

  findByProjectAndRoadmapStepForUpdate(...)

  동시에 여러 Self-Check 저장 요청이 들어와도
  단계당 Self-Check unique constraint 위반이나
  단계 상태 변경 경쟁이 발생하지 않도록 했습니다.

  Self-Check 저장 또는 단계 완료 처리 중 하나라도 실패하면
  전체 transaction이 rollback됩니다.

  ———

  ## 11. 단계 완료 처리

  유효한 Self-Check 저장이 완료되면
  현재 ProjectStep을 완료 처리합니다.

  selfCheckRepository.saveAndFlush(selfCheck);
  step.complete();

  완료 시 다음 값이 변경됩니다.

  status = COMPLETED
  completed_at = 현재 시각

  Self-Check 저장에 실패하면 단계 상태도 변경되지 않습니다.

  ———

  ## 12. 다음 단계 이동 제한

  다음 단계 프롬프트를 새로 생성하기 전에
  직전 단계 상태와 Self-Check 존재 여부를 검사합니다.

  previousStep.getStatus() == ProjectStepStatus.COMPLETED
  selfCheckRepository.existsByStep(previousStep)

  다음 조건 중 하나라도 충족하지 않으면
  신규 단계 프롬프트를 생성할 수 없습니다.

  - 직전 단계가 COMPLETED가 아님
  - 직전 단계의 Self-Check가 없음

  이를 통해 프론트 버튼 상태와 관계없이
  직접 API 호출로 단계 이동 정책을 우회하는 것을 방지합니다.

  직전 단계 조회를 위해 다음 Repository 메서드를 추가했습니다.

  Optional<ProjectStep> findByProjectAndStepOrder(
          Project project,
          Integer stepOrder
  );

  ———

  ## 13. 기존 프로젝트 호환성 정책

  기존 프로젝트에는 Self-Check 데이터가 없으므로
  모든 기존 단계를 즉시 차단하면 진행 중인 프로젝트를 사용할 수 없는 문제가 있습니다.

  이를 방지하기 위해 다음 정책을 적용했습니다.

  ### 이미 프롬프트가 발급된 단계

  기존 진행 단계로 인정하고 이전 Self-Check 검증 없이
  프롬프트 재조회와 현재 단계 진행을 허용합니다.

  기존 프롬프트 존재
  → 기존 프롬프트 반환
  → 단계 IN_PROGRESS 처리

  ### 아직 프롬프트가 발급되지 않은 신규 단계

  직전 단계의 완료 상태와 Self-Check 존재 여부를 검증합니다.

  기존 프롬프트 없음
  → 직전 단계 완료 및 Self-Check 검증
  → 신규 프롬프트 생성

  따라서 기존 프로젝트는 현재 발급된 단계부터 계속 진행할 수 있고,
  현재 단계의 결과물과 Self-Check를 제출한 이후부터
  새로운 진행 정책이 적용됩니다.

  과거 단계에 가짜 Self-Check 데이터를 생성하는 migration은 수행하지 않습니다.

  ———

  ## 14. 프로젝트 완료 조건 강화

  프로젝트 완료 API에서 마지막 단계의 Self-Check 존재 여부를 추가로 검증합니다.

  기존 조건:

  - 마지막 단계 결과물 존재
  - 결과물 내용이 비어 있지 않음

  변경된 조건:

  - 마지막 단계 결과물 존재
  - 결과물 내용이 비어 있지 않음
  - 마지막 단계 Self-Check 존재

  Self-Check가 없으면 프로젝트를 완료할 수 없습니다.

  SC001 SELF_CHECK_NOT_FOUND

  ———

  ## 15. Ownership 검증

  Self-Check 저장과 조회 모두 기존 ProjectValidator를 사용합니다.

  projectValidator.getProjectWithOwnershipCheck(userId, projectId)

  다음 항목을 검증합니다.

  - 프로젝트 존재 여부
  - 로그인한 사용자의 프로젝트인지 확인
  - 요청한 stepCode가 해당 RoadmapType에서 지원되는지 확인

  본인 프로젝트가 아니면 기존 예외 형식을 유지하여
  FORBIDDEN_ACCESS를 반환합니다.

  ———

  ## 16. 추가된 ErrorType

| Error Code | ErrorType | 설명 |
|---|---|---|
| SC001 | `SELF_CHECK_NOT_FOUND` | Self-Check를 제출하지 않음 |
| SC002 | `SELF_CHECK_ANSWER_TOO_SHORT` | 답변이 공백 제외 10자 미만 |
| SC003 | `PREVIOUS_STEP_NOT_COMPLETED` | 이전 단계 또는 Self-Check 미완료 |
| SC004 | `INVALID_SELF_CHECK_ITEMS` | 질문 누락, 중복 또는 잘못된 key |

  기존 BusinessException과 전역 예외 응답 형식을 그대로 사용합니다.

  ———

  ## 17. 테스트

  ### Self-Check Service 테스트

  다음 상황을 검증했습니다.

  - Self-Check 최초 저장
  - 저장 성공 후 단계 COMPLETED 처리
  - 기존 Self-Check overwrite
  - 저장된 Self-Check 조회
  - 미제출 상태에서 고정 질문 3개 반환
  - 10자 미만 답변 거부
  - 결과물 저장 전 Self-Check 제출 거부
  - 정의되지 않은 질문 key 거부
  - 다른 사용자의 프로젝트 접근 거부

  ### Self-Check Controller 테스트

  다음 API 동작을 검증했습니다.

  - Self-Check 저장 요청 및 응답 shape
  - Self-Check 조회 응답
  - 빈 답변 요청 validation

  ### Entity Mapping 테스트

  다음 JPA 매핑을 검증했습니다.

  - step_id unique constraint
  - check_items_json JSONB 매핑
  - @JdbcTypeCode(SqlTypes.JSON) 적용

  ### 단계 이동 테스트

  다음 진행 정책을 검증했습니다.

  - 직전 단계 미완료 시 다음 단계 진입 거부
  - 직전 단계 Self-Check 미제출 시 다음 단계 진입 거부
  - 기존 프로젝트의 선발급 프롬프트 재조회 허용

  ### 프로젝트 완료 테스트

  다음 완료 정책을 검증했습니다.

  - 마지막 단계 결과물이 없으면 완료 거부
  - 마지막 단계 Self-Check가 없으면 완료 거부
  - 결과물과 Self-Check가 모두 존재하면 완료 허용

  ———

  ## 18. 테스트 결과

  ./gradlew test --rerun-tasks

  결과:

  BUILD SUCCESSFUL

  추가 확인:

  git diff --check

  공백 및 diff 오류가 없음을 확인했습니다.

  ———

  ## 영향 범위

  변경되는 기존 기능:

  - 다음 단계 최초 프롬프트 생성
  - 프로젝트 완료 처리
  - 단계 상태 완료 처리

  변경되지 않는 기능:

  - 기존 프롬프트 조회 및 수정
  - 단계 결과물 저장 및 조회
  - AI 멘토 대화
  - 프로젝트 목록 및 상세 요약 응답
  - 기존 API 공통 응답 형식

  ———

  ## 제외 범위

  이번 PR에는 다음 기능을 포함하지 않습니다.

  - Self-Check revision 이력
  - 단계별로 서로 다른 Self-Check 질문
  - Self-Check 질문 관리용 DB 테이블
  - Self-Check 질문 관리자 CRUD
  - AI를 이용한 Self-Check 질문 생성
  - 멘토 프로젝트 상세 API 구현

  멘토 상세 API 구현 시에는 저장된 질문 snapshot과 답변을
  project_step_self_checks에서 조회해 응답에 포함할 예정입니다.

  ———

  ## 리뷰 포인트

  1. 공통 Self-Check 질문 3개의 문구와 key가 적절한지
  2. 답변 최소 길이 10자와 최대 길이 5,000자가 적절한지
  3. Self-Check 저장 시 단계 완료 처리 정책이 적절한지
  4. 기존 프롬프트가 존재하는 프로젝트에 대한 호환성 정책이 적절한지
  5. 프로젝트 완료 시 마지막 단계 Self-Check 검증이 충분한지